### PR TITLE
Align Laravel lifecycle events and broadcasting

### DIFF
--- a/custom/laravel/TASKS.md
+++ b/custom/laravel/TASKS.md
@@ -34,9 +34,9 @@ This document provides a comprehensive checklist for converting ClearLine from R
 - 🔄 Validate job retry/timeout policies mirror Rails (sidekiq settings → Laravel job properties/Horizon config).
 
 ### C. Events, Listeners & Broadcasting
-- ⬜ Inventory Rails events and callbacks; add Laravel Events/Listeners for conversation lifecycle, message lifecycle, SLA breaches, assignment changes, contact updates, portal/article updates.
-- ⬜ Confirm broadcasting channels (Reverb) are defined and guarded; align payload shapes with frontend expectations.
-- ⬜ Add audit/activity logging parity (reuse Spatie Activity Log where appropriate).
+- ✅ Inventory Rails events and callbacks; add Laravel Events/Listeners for conversation lifecycle, message lifecycle, SLA breaches, assignment changes, contact updates, portal/article updates.
+- ✅ Confirm broadcasting channels (Reverb) are defined and guarded; align payload shapes with frontend expectations.
+- ✅ Add audit/activity logging parity (reuse Spatie Activity Log where appropriate).
 
 ### D. Channel Integrations
 - ⬜ For each channel (email, API, web widget, WhatsApp, SMS/Twilio, Telegram, Line, Facebook, Twitter/X, Instagram, TikTok, Voice), document: inbound entrypoint, outbound sender, signature/auth, webhook verification, attachment handling, error paths.

--- a/custom/laravel/app/Actions/Assignment/AutoAssignConversationAction.php
+++ b/custom/laravel/app/Actions/Assignment/AutoAssignConversationAction.php
@@ -7,6 +7,7 @@ use App\Models\Inbox;
 use App\Models\User;
 use App\Models\InboxAssignmentPolicy;
 use App\Events\Conversation\ConversationAssigned;
+use App\Events\Conversation\ConversationUpdated;
 use App\Repositories\Conversation\ConversationRepository;
 use App\Repositories\Inbox\InboxRepository;
 use Illuminate\Support\Facades\DB;
@@ -47,6 +48,12 @@ class AutoAssignConversationAction
             $conversation = $this->conversationRepository->find($conversation->id);
 
             event(new ConversationAssigned($conversation, $agent, $previousAssignee));
+            event(new ConversationUpdated($conversation, [
+                'assignee_id' => [
+                    'previous' => $previousAssignee?->id,
+                    'current' => $agent->id,
+                ],
+            ]));
         }
 
         return $agent;

--- a/custom/laravel/app/Actions/Assignment/ManualAssignConversationAction.php
+++ b/custom/laravel/app/Actions/Assignment/ManualAssignConversationAction.php
@@ -2,6 +2,8 @@
 
 namespace App\Actions\Assignment;
 
+use App\Events\Conversation\ConversationAssigned;
+use App\Events\Conversation\ConversationUpdated;
 use App\Models\Conversation;
 use App\Models\User;
 use App\Repositories\Conversation\ConversationRepository;
@@ -23,9 +25,18 @@ class ManualAssignConversationAction
             'assignee_id' => $assignee->id,
         ]);
 
-        // Trigger event
-        // event(new ConversationAssigned($conversation, $assignee, $previousAssignee));
+        $conversation = $conversation->fresh();
 
-        return $conversation->fresh();
+        if ($previousAssignee?->id !== $assignee->id) {
+            event(new ConversationAssigned($conversation, $assignee, $previousAssignee));
+            event(new ConversationUpdated($conversation, [
+                'assignee_id' => [
+                    'previous' => $previousAssignee?->id,
+                    'current' => $assignee->id,
+                ],
+            ]));
+        }
+
+        return $conversation;
     }
 }

--- a/custom/laravel/app/Actions/Contact/CreateContactAction.php
+++ b/custom/laravel/app/Actions/Contact/CreateContactAction.php
@@ -3,6 +3,7 @@
 namespace App\Actions\Contact;
 
 use App\Data\Contact\ContactData;
+use App\Events\Contact\ContactCreated;
 use App\Models\Contact;
 use App\Repositories\Contact\ContactRepository;
 use Lorisleiva\Actions\Concerns\AsAction;
@@ -19,8 +20,7 @@ class CreateContactAction
     {
         $contact = $this->contactRepository->create($data->toArray());
 
-        // Trigger event
-        // event(new ContactCreated($contact));
+        event(new ContactCreated($contact));
 
         return $contact;
     }

--- a/custom/laravel/app/Actions/Contact/UpdateContactAction.php
+++ b/custom/laravel/app/Actions/Contact/UpdateContactAction.php
@@ -19,8 +19,10 @@ class UpdateContactAction
     {
         $this->contactRepository->update($contact->id, $data);
 
+        $contact->refresh();
+
         event(new ContactUpdated($contact));
 
-        return $contact->fresh();
+        return $contact;
     }
 }

--- a/custom/laravel/app/Actions/Contact/UpdateContactAction.php
+++ b/custom/laravel/app/Actions/Contact/UpdateContactAction.php
@@ -2,6 +2,7 @@
 
 namespace App\Actions\Contact;
 
+use App\Events\Contact\ContactUpdated;
 use App\Models\Contact;
 use App\Repositories\Contact\ContactRepository;
 use Lorisleiva\Actions\Concerns\AsAction;
@@ -18,8 +19,7 @@ class UpdateContactAction
     {
         $this->contactRepository->update($contact->id, $data);
 
-        // Trigger event
-        // event(new ContactUpdated($contact));
+        event(new ContactUpdated($contact));
 
         return $contact->fresh();
     }

--- a/custom/laravel/app/Actions/Conversation/AssignConversationAction.php
+++ b/custom/laravel/app/Actions/Conversation/AssignConversationAction.php
@@ -2,6 +2,8 @@
 
 namespace App\Actions\Conversation;
 
+use App\Events\Conversation\ConversationAssigned;
+use App\Events\Conversation\ConversationUpdated;
 use App\Models\Conversation;
 use App\Models\User;
 use App\Repositories\Conversation\ConversationRepository;
@@ -23,9 +25,18 @@ class AssignConversationAction
             'assignee_id' => $assignee?->id,
         ]);
 
-        // Trigger event
-        // event(new ConversationAssigned($conversation, $assignee, $previousAssignee));
+        $conversation = $conversation->fresh();
 
-        return $conversation->fresh();
+        if ($previousAssignee?->id !== $assignee?->id) {
+            event(new ConversationAssigned($conversation, $assignee, $previousAssignee));
+            event(new ConversationUpdated($conversation, [
+                'assignee_id' => [
+                    'previous' => $previousAssignee?->id,
+                    'current' => $assignee?->id,
+                ],
+            ]));
+        }
+
+        return $conversation;
     }
 }

--- a/custom/laravel/app/Actions/Conversation/AssignTeamAction.php
+++ b/custom/laravel/app/Actions/Conversation/AssignTeamAction.php
@@ -2,6 +2,7 @@
 
 namespace App\Actions\Conversation;
 
+use App\Events\Conversation\ConversationUpdated;
 use App\Models\Conversation;
 use App\Models\Team;
 use Lorisleiva\Actions\Concerns\AsAction;
@@ -13,10 +14,21 @@ class AssignTeamAction
 
     public function handle(Conversation $conversation, $teamId): Conversation
     {
+        $previousTeam = $conversation->team_id;
+
         // normalize unassign sentinel values
         if (is_null($teamId) || $teamId === '' || $teamId === 'nil' || $teamId === 0 || $teamId === '0') {
             $conversation->update(['team_id' => null]);
-            return $conversation->fresh();
+            $conversation = $conversation->fresh();
+
+            event(new ConversationUpdated($conversation, [
+                'team_id' => [
+                    'previous' => $previousTeam,
+                    'current' => null,
+                ],
+            ]));
+
+            return $conversation;
         }
 
         $team = Team::where('account_id', $conversation->account_id)->find($teamId);
@@ -28,6 +40,17 @@ class AssignTeamAction
 
         $conversation->update(['team_id' => $team->id]);
 
-        return $conversation->fresh();
+        $conversation = $conversation->fresh();
+
+        if ($previousTeam != $conversation->team_id) {
+            event(new ConversationUpdated($conversation, [
+                'team_id' => [
+                    'previous' => $previousTeam,
+                    'current' => $conversation->team_id,
+                ],
+            ]));
+        }
+
+        return $conversation;
     }
 }

--- a/custom/laravel/app/Actions/Conversation/AssignTeamAction.php
+++ b/custom/laravel/app/Actions/Conversation/AssignTeamAction.php
@@ -18,8 +18,12 @@ class AssignTeamAction
 
         // normalize unassign sentinel values
         if (is_null($teamId) || $teamId === '' || $teamId === 'nil' || $teamId === 0 || $teamId === '0') {
+            if (is_null($previousTeam)) {
+                return $conversation;
+            }
+
             $conversation->update(['team_id' => null]);
-            $conversation = $conversation->fresh();
+            $conversation->refresh();
 
             event(new ConversationUpdated($conversation, [
                 'team_id' => [
@@ -35,12 +39,13 @@ class AssignTeamAction
 
         if (! $team) {
             Log::warning('AssignTeamAction: team not found or does not belong to account', ['team_id' => $teamId, 'account_id' => $conversation->account_id]);
-            return $conversation->fresh();
+            $conversation->refresh();
+            return $conversation;
         }
 
         $conversation->update(['team_id' => $team->id]);
 
-        $conversation = $conversation->fresh();
+        $conversation->refresh();
 
         if ($previousTeam != $conversation->team_id) {
             event(new ConversationUpdated($conversation, [

--- a/custom/laravel/app/Actions/Conversation/ChangePriorityAction.php
+++ b/custom/laravel/app/Actions/Conversation/ChangePriorityAction.php
@@ -2,6 +2,7 @@
 
 namespace App\Actions\Conversation;
 
+use App\Events\Conversation\ConversationUpdated;
 use App\Models\Conversation;
 use Lorisleiva\Actions\Concerns\AsAction;
 
@@ -11,6 +12,8 @@ class ChangePriorityAction
 
     public function handle(Conversation $conversation, $priority): Conversation
     {
+        $previousPriority = $conversation->priority;
+
         // Treat 'nil' (string) as explicit null
         if ($priority === 'nil' || $priority === 'null' || $priority === '' || $priority === null) {
             $conversation->update(['priority' => null]);
@@ -18,6 +21,17 @@ class ChangePriorityAction
             $conversation->update(['priority' => $priority]);
         }
 
-        return $conversation->fresh();
+        $conversation = $conversation->fresh();
+
+        if ($previousPriority != $conversation->priority) {
+            event(new ConversationUpdated($conversation, [
+                'priority' => [
+                    'previous' => $previousPriority,
+                    'current' => $conversation->priority,
+                ],
+            ]));
+        }
+
+        return $conversation;
     }
 }

--- a/custom/laravel/app/Actions/Conversation/CloseConversationAction.php
+++ b/custom/laravel/app/Actions/Conversation/CloseConversationAction.php
@@ -2,6 +2,8 @@
 
 namespace App\Actions\Conversation;
 
+use App\Events\Conversation\ConversationStatusChanged;
+use App\Events\Conversation\ConversationUpdated;
 use App\Models\Conversation;
 use App\Repositories\Conversation\ConversationRepository;
 use Lorisleiva\Actions\Concerns\AsAction;
@@ -22,9 +24,18 @@ class CloseConversationAction
             'status' => Conversation::STATUS_RESOLVED,
         ]);
 
-        // Trigger event
-        // event(new ConversationStatusChanged($conversation, $previousStatus, Conversation::STATUS_RESOLVED));
+        $conversation = $conversation->fresh();
 
-        return $conversation->fresh();
+        if ($previousStatus !== Conversation::STATUS_RESOLVED) {
+            event(new ConversationStatusChanged($conversation, $previousStatus, Conversation::STATUS_RESOLVED));
+            event(new ConversationUpdated($conversation, [
+                'status' => [
+                    'previous' => $previousStatus,
+                    'current' => Conversation::STATUS_RESOLVED,
+                ],
+            ]));
+        }
+
+        return $conversation;
     }
 }

--- a/custom/laravel/app/Actions/Conversation/CreateConversationAction.php
+++ b/custom/laravel/app/Actions/Conversation/CreateConversationAction.php
@@ -3,6 +3,7 @@
 namespace App\Actions\Conversation;
 
 use App\Data\Conversation\ConversationData;
+use App\Events\Conversation\ConversationCreated;
 use App\Models\Conversation;
 use App\Repositories\Conversation\ConversationRepository;
 use Illuminate\Support\Str;
@@ -24,8 +25,7 @@ class CreateConversationAction
 
         $conversation = $this->conversationRepository->create($conversationData);
 
-        // Trigger event
-        // event(new ConversationCreated($conversation));
+        event(new ConversationCreated($conversation));
 
         return $conversation;
     }

--- a/custom/laravel/app/Actions/Conversation/UpdateConversationAction.php
+++ b/custom/laravel/app/Actions/Conversation/UpdateConversationAction.php
@@ -6,6 +6,7 @@ use App\Events\Conversation\ConversationStatusChanged;
 use App\Events\Conversation\ConversationUpdated;
 use App\Models\Conversation;
 use App\Repositories\Conversation\ConversationRepository;
+use Illuminate\Support\Carbon;
 use Lorisleiva\Actions\Concerns\AsAction;
 
 class UpdateConversationAction
@@ -77,7 +78,12 @@ class UpdateConversationAction
                 $previous = json_decode($previous, true);
             }
 
-            if ($previous != $current) {
+            if ($field === 'snoozed_until') {
+                $previous = $previous ? Carbon::parse($previous)->toIso8601String() : null;
+                $current = $current ? ($current instanceof Carbon ? $current->toIso8601String() : Carbon::parse($current)->toIso8601String()) : null;
+            }
+
+            if ($previous !== $current) {
                 $changes[$field] = [
                     'previous' => $previous,
                     'current' => $current,

--- a/custom/laravel/app/Actions/Conversation/UpdateConversationAction.php
+++ b/custom/laravel/app/Actions/Conversation/UpdateConversationAction.php
@@ -73,6 +73,10 @@ class UpdateConversationAction
             $previous = $original[$field] ?? null;
             $current = $conversation->{$field};
 
+            if ($field === 'custom_attributes' && is_string($previous)) {
+                $previous = json_decode($previous, true);
+            }
+
             if ($previous != $current) {
                 $changes[$field] = [
                     'previous' => $previous,

--- a/custom/laravel/app/Actions/Conversation/UpdateConversationAction.php
+++ b/custom/laravel/app/Actions/Conversation/UpdateConversationAction.php
@@ -2,6 +2,8 @@
 
 namespace App\Actions\Conversation;
 
+use App\Events\Conversation\ConversationStatusChanged;
+use App\Events\Conversation\ConversationUpdated;
 use App\Models\Conversation;
 use App\Repositories\Conversation\ConversationRepository;
 use Lorisleiva\Actions\Concerns\AsAction;
@@ -16,6 +18,8 @@ class UpdateConversationAction
 
     public function handle(Conversation $conversation, array $data): Conversation
     {
+        $original = $conversation->getOriginal();
+
         // Normalize some legacy sentinel values to null like Rails behavior
         if (array_key_exists('priority', $data)) {
             if ($data['priority'] === 'nil' || $data['priority'] === 'null' || $data['priority'] === '') {
@@ -37,9 +41,46 @@ class UpdateConversationAction
 
         $this->conversationRepository->update($conversation->id, $data);
 
-        // Trigger event
-        // event(new ConversationUpdated($conversation));
+        $conversation->refresh();
 
-        return $conversation->fresh();
+        $changes = $this->detectChanges($conversation, $original, $data);
+
+        if (array_key_exists('status', $changes)) {
+            event(new ConversationStatusChanged(
+                $conversation,
+                $changes['status']['previous'],
+                $changes['status']['current']
+            ));
+        }
+
+        if (! empty($changes)) {
+            event(new ConversationUpdated($conversation, $changes));
+        }
+
+        return $conversation;
+    }
+
+    private function detectChanges(Conversation $conversation, array $original, array $payload): array
+    {
+        $tracked = ['status', 'priority', 'team_id', 'assignee_id', 'snoozed_until', 'custom_attributes'];
+        $changes = [];
+
+        foreach ($tracked as $field) {
+            if (! array_key_exists($field, $payload)) {
+                continue;
+            }
+
+            $previous = $original[$field] ?? null;
+            $current = $conversation->{$field};
+
+            if ($previous != $current) {
+                $changes[$field] = [
+                    'previous' => $previous,
+                    'current' => $current,
+                ];
+            }
+        }
+
+        return $changes;
     }
 }

--- a/custom/laravel/app/Actions/Message/CreateMessageAction.php
+++ b/custom/laravel/app/Actions/Message/CreateMessageAction.php
@@ -3,6 +3,7 @@
 namespace App\Actions\Message;
 
 use App\Data\Message\MessageData;
+use App\Events\Message\MessageCreated;
 use App\Models\Message;
 use App\Repositories\Conversation\ConversationRepository;
 use App\Repositories\Message\MessageRepository;
@@ -50,7 +51,7 @@ class CreateMessageAction
             }
 
             // Trigger event
-            // event(new MessageCreated($message));
+            event(new MessageCreated($message));
 
             return $message;
         });

--- a/custom/laravel/app/Actions/Message/DeleteMessageAction.php
+++ b/custom/laravel/app/Actions/Message/DeleteMessageAction.php
@@ -2,6 +2,7 @@
 
 namespace App\Actions\Message;
 
+use App\Events\Message\MessageDeleted;
 use App\Models\Message;
 use App\Repositories\Message\MessageRepository;
 use Lorisleiva\Actions\Concerns\AsAction;
@@ -16,8 +17,7 @@ class DeleteMessageAction
 
     public function handle(Message $message): bool
     {
-        // Trigger event
-        // event(new MessageDeleted($message));
+        event(new MessageDeleted($message));
 
         return $this->messageRepository->delete($message->id);
     }

--- a/custom/laravel/app/Actions/Message/UpdateMessageAction.php
+++ b/custom/laravel/app/Actions/Message/UpdateMessageAction.php
@@ -21,6 +21,10 @@ class UpdateMessageAction
 
         $message = $message->fresh();
 
+        if (! $message) {
+            throw new \RuntimeException('Message was not found after update.');
+        }
+
         event(new MessageUpdated($message));
 
         return $message;

--- a/custom/laravel/app/Actions/Message/UpdateMessageAction.php
+++ b/custom/laravel/app/Actions/Message/UpdateMessageAction.php
@@ -2,6 +2,7 @@
 
 namespace App\Actions\Message;
 
+use App\Events\Message\MessageUpdated;
 use App\Models\Message;
 use App\Repositories\Message\MessageRepository;
 use Lorisleiva\Actions\Concerns\AsAction;
@@ -18,9 +19,10 @@ class UpdateMessageAction
     {
         $this->messageRepository->update($message->id, $data);
 
-        // Trigger event
-        // event(new MessageUpdated($message));
+        $message = $message->fresh();
 
-        return $message->fresh();
+        event(new MessageUpdated($message));
+
+        return $message;
     }
 }

--- a/custom/laravel/app/Events/Article/ArticleUpdated.php
+++ b/custom/laravel/app/Events/Article/ArticleUpdated.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Events\Article;
+
+use App\Http\Resources\Article\ArticleResource;
+use App\Models\Article;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Broadcasting\PrivateChannel;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class ArticleUpdated implements ShouldBroadcast
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    public function __construct(
+        public Article $article,
+        public string $action = 'updated',
+        public ?int $previousStatus = null
+    ) {}
+
+    public function broadcastOn(): array
+    {
+        return [
+            new PrivateChannel("account.{$this->article->account_id}"),
+            new PrivateChannel("portal.{$this->article->portal_id}"),
+            new PrivateChannel("article.{$this->article->id}"),
+        ];
+    }
+
+    public function broadcastAs(): string
+    {
+        return 'article.' . $this->action;
+    }
+
+    public function broadcastWith(): array
+    {
+        return [
+            'article' => new ArticleResource($this->article),
+            'action' => $this->action,
+            'previous_status' => $this->previousStatus,
+        ];
+    }
+}

--- a/custom/laravel/app/Events/Article/ArticleUpdated.php
+++ b/custom/laravel/app/Events/Article/ArticleUpdated.php
@@ -6,11 +6,11 @@ use App\Http\Resources\Article\ArticleResource;
 use App\Models\Article;
 use Illuminate\Broadcasting\InteractsWithSockets;
 use Illuminate\Broadcasting\PrivateChannel;
-use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcastNow;
 use Illuminate\Foundation\Events\Dispatchable;
 use Illuminate\Queue\SerializesModels;
 
-class ArticleUpdated implements ShouldBroadcast
+class ArticleUpdated implements ShouldBroadcastNow
 {
     use Dispatchable, InteractsWithSockets, SerializesModels;
 

--- a/custom/laravel/app/Events/Conversation/ConversationUpdated.php
+++ b/custom/laravel/app/Events/Conversation/ConversationUpdated.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Events\Conversation;
+
+use App\Http\Resources\Conversation\ConversationResource;
+use App\Models\Conversation;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Broadcasting\PrivateChannel;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class ConversationUpdated implements ShouldBroadcast
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    public function __construct(public Conversation $conversation, public array $changes = []) {}
+
+    public function broadcastOn(): array
+    {
+        return [
+            new PrivateChannel("account.{$this->conversation->account_id}"),
+            new PrivateChannel("conversation.{$this->conversation->id}"),
+        ];
+    }
+
+    public function broadcastAs(): string
+    {
+        return 'conversation.updated';
+    }
+
+    public function broadcastWith(): array
+    {
+        return [
+            'conversation' => new ConversationResource($this->conversation),
+            'changes' => $this->changes,
+        ];
+    }
+}

--- a/custom/laravel/app/Events/Message/MessageDeleted.php
+++ b/custom/laravel/app/Events/Message/MessageDeleted.php
@@ -2,7 +2,6 @@
 
 namespace App\Events\Message;
 
-use App\Http\Resources\Message\MessageResource;
 use App\Models\Message;
 use Illuminate\Broadcasting\InteractsWithSockets;
 use Illuminate\Broadcasting\PrivateChannel;
@@ -10,7 +9,7 @@ use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
 use Illuminate\Foundation\Events\Dispatchable;
 use Illuminate\Queue\SerializesModels;
 
-class MessageUpdated implements ShouldBroadcast
+class MessageDeleted implements ShouldBroadcast
 {
     use Dispatchable, InteractsWithSockets, SerializesModels;
 
@@ -26,13 +25,13 @@ class MessageUpdated implements ShouldBroadcast
 
     public function broadcastAs(): string
     {
-        return 'message.updated';
+        return 'message.deleted';
     }
 
     public function broadcastWith(): array
     {
         return [
-            'message' => new MessageResource($this->message),
+            'message_id' => $this->message->id,
             'conversation_id' => $this->message->conversation_id,
         ];
     }

--- a/custom/laravel/app/Events/Portal/PortalUpdated.php
+++ b/custom/laravel/app/Events/Portal/PortalUpdated.php
@@ -1,39 +1,39 @@
 <?php
 
-namespace App\Events\Message;
+namespace App\Events\Portal;
 
-use App\Http\Resources\Message\MessageResource;
-use App\Models\Message;
+use App\Http\Resources\Portal\PortalResource;
+use App\Models\Portal;
 use Illuminate\Broadcasting\InteractsWithSockets;
 use Illuminate\Broadcasting\PrivateChannel;
 use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
 use Illuminate\Foundation\Events\Dispatchable;
 use Illuminate\Queue\SerializesModels;
 
-class MessageUpdated implements ShouldBroadcast
+class PortalUpdated implements ShouldBroadcast
 {
     use Dispatchable, InteractsWithSockets, SerializesModels;
 
-    public function __construct(public Message $message) {}
+    public function __construct(public Portal $portal, public string $action = 'updated') {}
 
     public function broadcastOn(): array
     {
         return [
-            new PrivateChannel("account.{$this->message->account_id}"),
-            new PrivateChannel("conversation.{$this->message->conversation_id}"),
+            new PrivateChannel("account.{$this->portal->account_id}"),
+            new PrivateChannel("portal.{$this->portal->id}"),
         ];
     }
 
     public function broadcastAs(): string
     {
-        return 'message.updated';
+        return 'portal.' . $this->action;
     }
 
     public function broadcastWith(): array
     {
         return [
-            'message' => new MessageResource($this->message),
-            'conversation_id' => $this->message->conversation_id,
+            'portal' => new PortalResource($this->portal),
+            'action' => $this->action,
         ];
     }
 }

--- a/custom/laravel/app/Events/Portal/PortalUpdated.php
+++ b/custom/laravel/app/Events/Portal/PortalUpdated.php
@@ -6,11 +6,11 @@ use App\Http\Resources\Portal\PortalResource;
 use App\Models\Portal;
 use Illuminate\Broadcasting\InteractsWithSockets;
 use Illuminate\Broadcasting\PrivateChannel;
-use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcastNow;
 use Illuminate\Foundation\Events\Dispatchable;
 use Illuminate\Queue\SerializesModels;
 
-class PortalUpdated implements ShouldBroadcast
+class PortalUpdated implements ShouldBroadcastNow
 {
     use Dispatchable, InteractsWithSockets, SerializesModels;
 

--- a/custom/laravel/app/Events/Sla/SlaBreached.php
+++ b/custom/laravel/app/Events/Sla/SlaBreached.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Events\Sla;
+
+use App\Models\AppliedSla;
+use App\Models\Conversation;
+use App\Models\SlaPolicy;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Broadcasting\PrivateChannel;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class SlaBreached implements ShouldBroadcast
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    public function __construct(
+        public Conversation $conversation,
+        public SlaPolicy $policy,
+        public array $breaches,
+        public ?AppliedSla $appliedSla = null
+    ) {}
+
+    public function broadcastOn(): array
+    {
+        return [
+            new PrivateChannel("account.{$this->conversation->account_id}"),
+            new PrivateChannel("conversation.{$this->conversation->id}"),
+        ];
+    }
+
+    public function broadcastAs(): string
+    {
+        return 'sla.breached';
+    }
+
+    public function broadcastWith(): array
+    {
+        return [
+            'conversation_id' => $this->conversation->id,
+            'policy_id' => $this->policy->id,
+            'breaches' => $this->breaches,
+            'applied_sla_id' => $this->appliedSla?->id,
+        ];
+    }
+}

--- a/custom/laravel/app/Http/Controllers/Api/V1/ArticlesController.php
+++ b/custom/laravel/app/Http/Controllers/Api/V1/ArticlesController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\Api\V1;
 
 use App\Http\Controllers\Controller;
+use App\Events\Article\ArticleUpdated;
 use App\Models\Account;
 use App\Models\Article;
 use App\Models\Portal;
@@ -55,7 +56,10 @@ class ArticlesController extends Controller
             'portal_id' => $portal->id,
             'account_id' => $account->id,
             'author_id' => $validated['author_id'] ?? auth()->id(),
+            'status' => $this->normalizeStatus($validated['status'] ?? null, Article::STATUS_DRAFT),
         ]);
+
+        event(new ArticleUpdated($article, 'created'));
 
         return response()->json(['data' => $article], 201);
     }
@@ -79,6 +83,8 @@ class ArticlesController extends Controller
         abort_unless($portal->account_id === $account->id, 404);
         abort_unless($article->portal_id === $portal->id, 404);
 
+        $previousStatus = $article->status;
+
         $validated = $request->validate([
             'title' => 'string|max:255',
             'slug' => 'string|max:255',
@@ -89,7 +95,15 @@ class ArticlesController extends Controller
             'meta' => 'nullable|array',
         ]);
 
+        if (array_key_exists('status', $validated)) {
+            $validated['status'] = $this->normalizeStatus($validated['status'], $article->status);
+        }
+
         $article->update($validated);
+
+        $article->refresh();
+
+        event(new ArticleUpdated($article, $this->resolveAction($previousStatus, $article->status), $previousStatus));
 
         return response()->json(['data' => $article]);
     }
@@ -102,8 +116,36 @@ class ArticlesController extends Controller
         abort_unless($portal->account_id === $account->id, 404);
         abort_unless($article->portal_id === $portal->id, 404);
 
+        event(new ArticleUpdated($article, 'deleted'));
+
         $article->delete();
 
         return response()->json(null, 204);
+    }
+
+    private function normalizeStatus(?string $status, int $default): int
+    {
+        if (is_null($status)) {
+            return $default;
+        }
+
+        return match ($status) {
+            'published' => Article::STATUS_PUBLISHED,
+            'archived' => Article::STATUS_ARCHIVED,
+            default => Article::STATUS_DRAFT,
+        };
+    }
+
+    private function resolveAction(int $previousStatus, int $currentStatus): string
+    {
+        if ($previousStatus !== $currentStatus) {
+            return match ($currentStatus) {
+                Article::STATUS_PUBLISHED => 'published',
+                Article::STATUS_ARCHIVED => 'archived',
+                default => 'updated',
+            };
+        }
+
+        return 'updated';
     }
 }

--- a/custom/laravel/app/Http/Controllers/Api/V1/ConversationsController.php
+++ b/custom/laravel/app/Http/Controllers/Api/V1/ConversationsController.php
@@ -193,16 +193,14 @@ class ConversationsController extends Controller
     {
         abort_unless($conversation->account_id === $account->id, 404);
 
-        if ($request->has('status')) {
-            $conversation->status = $request->input('status');
-            if ($request->has('snoozed_until')) {
-                $conversation->snoozed_until = $request->input('snoozed_until');
-            }
-        } else {
-            $conversation->status = $conversation->status === 'open' ? 'resolved' : 'open';
+        $status = $this->normalizeStatus($request, $conversation);
+        $payload = ['status' => $status];
+
+        if ($request->has('snoozed_until')) {
+            $payload['snoozed_until'] = $request->input('snoozed_until');
         }
 
-        $conversation->save();
+        $conversation = UpdateConversationAction::run($conversation, $payload);
 
         return new ConversationResource($conversation->load('contact', 'inbox', 'assignee'));
     }
@@ -326,7 +324,7 @@ class ConversationsController extends Controller
     {
         abort_unless($conversation->account_id === $account->id, 404);
 
-        $conversation->update([
+        $conversation = UpdateConversationAction::run($conversation, [
             'custom_attributes' => $request->input('custom_attributes', []),
         ]);
 
@@ -365,5 +363,22 @@ class ConversationsController extends Controller
         $conversation->delete();
 
         return response()->json(null, 204);
+    }
+
+    private function normalizeStatus(Request $request, Conversation $conversation): int
+    {
+        if ($request->has('status')) {
+            $status = $request->input('status');
+            return match ($status) {
+                'open', Conversation::STATUS_OPEN => Conversation::STATUS_OPEN,
+                'pending', Conversation::STATUS_PENDING => Conversation::STATUS_PENDING,
+                'snoozed', Conversation::STATUS_SNOOZED => Conversation::STATUS_SNOOZED,
+                default => Conversation::STATUS_RESOLVED,
+            };
+        }
+
+        return $conversation->status === Conversation::STATUS_OPEN
+            ? Conversation::STATUS_RESOLVED
+            : Conversation::STATUS_OPEN;
     }
 }

--- a/custom/laravel/app/Http/Controllers/Api/V1/PortalsController.php
+++ b/custom/laravel/app/Http/Controllers/Api/V1/PortalsController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\Api\V1;
 
 use App\Http\Controllers\Controller;
+use App\Events\Portal\PortalUpdated;
 use App\Models\Account;
 use App\Models\Portal;
 use Illuminate\Http\JsonResponse;
@@ -35,6 +36,8 @@ class PortalsController extends Controller
 
         $portal = Portal::create(array_merge($validated, ['account_id' => $account->id]));
 
+        event(new PortalUpdated($portal, 'created'));
+
         return response()->json(['data' => $portal], 201);
     }
 
@@ -62,12 +65,18 @@ class PortalsController extends Controller
 
         $portal->update($validated);
 
+        $portal->refresh();
+
+        event(new PortalUpdated($portal, 'updated'));
+
         return response()->json(['data' => $portal]);
     }
 
     public function destroy(Account $account, Portal $portal): JsonResponse
     {
         abort_unless($portal->account_id === $account->id, 404);
+
+        event(new PortalUpdated($portal, 'deleted'));
 
         $portal->delete();
 

--- a/custom/laravel/app/Http/Controllers/Api/V1/Public/Inboxes/ConversationsController.php
+++ b/custom/laravel/app/Http/Controllers/Api/V1/Public/Inboxes/ConversationsController.php
@@ -3,6 +3,9 @@
 namespace App\Http\Controllers\Api\V1\Public\Inboxes;
 
 use App\Http\Controllers\Controller;
+use App\Actions\Conversation\UpdateConversationAction;
+use App\Events\Conversation\ConversationCreated;
+use App\Events\Message\MessageCreated;
 use App\Models\Contact;
 use App\Models\ContactInbox;
 use App\Models\Conversation;
@@ -80,23 +83,27 @@ class ConversationsController extends Controller
             'inbox_id' => $inbox->id,
             'contact_id' => $contact->id,
             'contact_inbox_id' => $contactInbox->id,
-            'status' => 'open',
+            'status' => Conversation::STATUS_OPEN,
             'uuid' => Str::uuid()->toString(),
             'custom_attributes' => $validated['custom_attributes'] ?? [],
             'last_activity_at' => now(),
         ]);
 
+        event(new ConversationCreated($conversation));
+
         // Create initial message if provided
         if (!empty($validated['message']['content'])) {
-            Message::create([
+            $message = Message::create([
                 'account_id' => $inbox->account_id,
                 'inbox_id' => $inbox->id,
                 'conversation_id' => $conversation->id,
                 'content' => $validated['message']['content'],
-                'message_type' => 0, // incoming
+                'message_type' => Message::TYPE_INCOMING,
                 'sender_type' => Contact::class,
                 'sender_id' => $contact->id,
             ]);
+
+            event(new MessageCreated($message));
         }
 
         return response()->json([
@@ -145,8 +152,10 @@ class ConversationsController extends Controller
             return response()->json(['error' => 'Conversation not found'], 404);
         }
 
-        $conversation->update([
-            'status' => $conversation->status === 'open' ? 'resolved' : 'open',
+        $conversation = UpdateConversationAction::run($conversation, [
+            'status' => $conversation->status === Conversation::STATUS_OPEN
+                ? Conversation::STATUS_RESOLVED
+                : Conversation::STATUS_OPEN,
         ]);
 
         return response()->json([

--- a/custom/laravel/app/Http/Controllers/Api/V1/Public/Inboxes/MessagesController.php
+++ b/custom/laravel/app/Http/Controllers/Api/V1/Public/Inboxes/MessagesController.php
@@ -3,6 +3,8 @@
 namespace App\Http\Controllers\Api\V1\Public\Inboxes;
 
 use App\Http\Controllers\Controller;
+use App\Events\Message\MessageCreated;
+use App\Events\Message\MessageUpdated;
 use App\Models\Contact;
 use App\Models\ContactInbox;
 use App\Models\Conversation;
@@ -79,7 +81,7 @@ class MessagesController extends Controller
             'inbox_id' => $inbox->id,
             'conversation_id' => $conversation->id,
             'content' => $validated['content'] ?? '',
-            'message_type' => 0, // incoming
+            'message_type' => Message::TYPE_INCOMING,
             'sender_type' => Contact::class,
             'sender_id' => $contact->id,
             'external_source_id_echo' => $validated['echo_id'] ?? null,
@@ -87,6 +89,8 @@ class MessagesController extends Controller
 
         // Update conversation last activity
         $conversation->update(['last_activity_at' => now()]);
+
+        event(new MessageCreated($message));
 
         return response()->json($this->formatMessage($message), 201);
     }
@@ -120,6 +124,8 @@ class MessagesController extends Controller
                 $validated
             ),
         ]);
+
+        event(new MessageUpdated($message));
 
         return response()->json($this->formatMessage($message));
     }

--- a/custom/laravel/app/Http/Controllers/Api/V1/Widget/ConversationsController.php
+++ b/custom/laravel/app/Http/Controllers/Api/V1/Widget/ConversationsController.php
@@ -2,9 +2,15 @@
 
 namespace App\Http\Controllers\Api\V1\Widget;
 
+use App\Actions\Conversation\UpdateConversationAction;
+use App\Events\Contact\ContactCreated;
+use App\Events\Conversation\ConversationCreated;
+use App\Events\Message\MessageCreated;
 use App\Models\Contact;
 use App\Models\ContactInbox;
 use App\Models\Conversation;
+use App\Models\Inbox;
+use App\Models\Message;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Str;
@@ -64,7 +70,7 @@ class ConversationsController extends BaseController
         ]);
 
         // Find the inbox by website token
-        $inbox = \App\Models\Inbox::where('channel_type', 'Channel::WebWidget')
+        $inbox = Inbox::where('channel_type', 'Channel::WebWidget')
             ->whereHas('channel', function ($query) use ($validated) {
                 $query->where('website_token', $validated['website_token']);
             })
@@ -88,6 +94,8 @@ class ConversationsController extends BaseController
                 'custom_attributes' => $validated['contact']['custom_attributes'] ?? [],
             ]);
 
+            event(new ContactCreated($contact));
+
             // Create contact inbox
             $contactInbox = ContactInbox::create([
                 'contact_id' => $contact->id,
@@ -102,22 +110,26 @@ class ConversationsController extends BaseController
             'inbox_id' => $inbox->id,
             'contact_id' => $contactInbox->contact_id,
             'contact_inbox_id' => $contactInbox->id,
-            'status' => 'open',
+            'status' => Conversation::STATUS_OPEN,
             'uuid' => Str::uuid()->toString(),
             'custom_attributes' => $validated['custom_attributes'] ?? [],
             'last_activity_at' => now(),
         ]);
 
+        event(new ConversationCreated($conversation));
+
         // Create initial message if provided
         if (!empty($validated['message']['content'])) {
-            $conversation->messages()->create([
+            $message = $conversation->messages()->create([
                 'account_id' => $inbox->account_id,
                 'inbox_id' => $inbox->id,
                 'content' => $validated['message']['content'],
-                'message_type' => 0, // incoming
+                'message_type' => Message::TYPE_INCOMING,
                 'sender_type' => Contact::class,
                 'sender_id' => $contactInbox->contact_id,
             ]);
+
+            event(new MessageCreated($message));
         }
 
         return response()->json([
@@ -147,7 +159,7 @@ class ConversationsController extends BaseController
 
         // Get the most recent open conversation
         $conversation = Conversation::where('contact_inbox_id', $contactInbox->id)
-            ->where('status', 'open')
+            ->where('status', Conversation::STATUS_OPEN)
             ->latest()
             ->first();
 
@@ -155,7 +167,9 @@ class ConversationsController extends BaseController
             return response()->json(['error' => 'Conversation not found'], 404);
         }
 
-        $conversation->update(['status' => 'resolved']);
+        $conversation = UpdateConversationAction::run($conversation, [
+            'status' => Conversation::STATUS_RESOLVED,
+        ]);
 
         return response()->json([
             'id' => $conversation->id,
@@ -232,7 +246,7 @@ class ConversationsController extends BaseController
             return response()->json(['error' => 'Conversation not found'], 404);
         }
 
-        $conversation->update([
+        UpdateConversationAction::run($conversation, [
             'custom_attributes' => array_merge(
                 $conversation->custom_attributes ?? [],
                 $validated['custom_attributes']
@@ -272,7 +286,7 @@ class ConversationsController extends BaseController
             unset($customAttributes[$key]);
         }
 
-        $conversation->update(['custom_attributes' => $customAttributes]);
+        UpdateConversationAction::run($conversation, ['custom_attributes' => $customAttributes]);
 
         return response()->json(['success' => true]);
     }

--- a/custom/laravel/app/Http/Controllers/Api/V1/Widget/MessagesController.php
+++ b/custom/laravel/app/Http/Controllers/Api/V1/Widget/MessagesController.php
@@ -2,6 +2,9 @@
 
 namespace App\Http\Controllers\Api\V1\Widget;
 
+use App\Events\Conversation\ConversationCreated;
+use App\Events\Message\MessageCreated;
+use App\Events\Message\MessageUpdated;
 use App\Models\Conversation;
 use App\Models\Message;
 use Illuminate\Http\JsonResponse;
@@ -84,7 +87,7 @@ class MessagesController extends BaseController
 
         // Get or create conversation
         $conversation = Conversation::where('contact_inbox_id', $contactInbox->id)
-            ->where('status', '!=', 'resolved')
+            ->where('status', '!=', Conversation::STATUS_RESOLVED)
             ->latest()
             ->first();
 
@@ -95,10 +98,12 @@ class MessagesController extends BaseController
                 'inbox_id' => $contactInbox->inbox_id,
                 'contact_id' => $contactInbox->contact_id,
                 'contact_inbox_id' => $contactInbox->id,
-                'status' => 'open',
+                'status' => Conversation::STATUS_OPEN,
                 'uuid' => \Illuminate\Support\Str::uuid()->toString(),
                 'last_activity_at' => now(),
             ]);
+
+            event(new ConversationCreated($conversation));
         }
 
         // Create the message
@@ -107,7 +112,7 @@ class MessagesController extends BaseController
             'inbox_id' => $contactInbox->inbox_id,
             'conversation_id' => $conversation->id,
             'content' => $validated['content'] ?? '',
-            'message_type' => 0, // incoming
+            'message_type' => Message::TYPE_INCOMING,
             'sender_type' => \App\Models\Contact::class,
             'sender_id' => $contactInbox->contact_id,
             'external_source_id_echo' => $validated['echo_id'] ?? null,
@@ -126,6 +131,8 @@ class MessagesController extends BaseController
                 ]);
             }
         }
+
+        event(new MessageCreated($message->fresh('attachments')));
 
         return response()->json($this->formatMessage($message->load('attachments')), 201);
     }
@@ -160,6 +167,8 @@ class MessagesController extends BaseController
                 $validated
             ),
         ]);
+
+        event(new MessageUpdated($message));
 
         return response()->json($this->formatMessage($message));
     }

--- a/custom/laravel/app/Http/Resources/Article/ArticleResource.php
+++ b/custom/laravel/app/Http/Resources/Article/ArticleResource.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Http\Resources\Article;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class ArticleResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'account_id' => $this->account_id,
+            'portal_id' => $this->portal_id,
+            'category_id' => $this->category_id,
+            'folder_id' => $this->folder_id,
+            'author_id' => $this->author_id,
+            'associated_article_id' => $this->associated_article_id,
+            'title' => $this->title,
+            'slug' => $this->slug,
+            'description' => $this->description,
+            'content' => $this->content,
+            'status' => $this->status,
+            'status_label' => $this->statusLabel(),
+            'position' => $this->position,
+            'views' => $this->views,
+            'locale' => $this->locale,
+            'meta' => $this->meta,
+            'created_at' => $this->created_at?->toISOString(),
+            'updated_at' => $this->updated_at?->toISOString(),
+        ];
+    }
+
+    private function statusLabel(): string
+    {
+        return match ((int) $this->status) {
+            \App\Models\Article::STATUS_PUBLISHED => 'published',
+            \App\Models\Article::STATUS_ARCHIVED => 'archived',
+            default => 'draft',
+        };
+    }
+}

--- a/custom/laravel/app/Http/Resources/Portal/PortalResource.php
+++ b/custom/laravel/app/Http/Resources/Portal/PortalResource.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Http\Resources\Portal;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class PortalResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'account_id' => $this->account_id,
+            'name' => $this->name,
+            'slug' => $this->slug,
+            'custom_domain' => $this->custom_domain,
+            'color' => $this->color,
+            'homepage_link' => $this->homepage_link,
+            'page_title' => $this->page_title,
+            'header_text' => $this->header_text,
+            'archived' => $this->archived,
+            'config' => $this->config,
+            'ssl_settings' => $this->ssl_settings,
+            'created_at' => $this->created_at?->toISOString(),
+            'updated_at' => $this->updated_at?->toISOString(),
+        ];
+    }
+}

--- a/custom/laravel/app/Jobs/Sla/CheckSlaJob.php
+++ b/custom/laravel/app/Jobs/Sla/CheckSlaJob.php
@@ -11,7 +11,7 @@ use Illuminate\Support\Facades\Log;
 use App\Models\Conversation;
 use App\Models\SlaPolicy;
 use App\Models\AppliedSla;
-use App\Jobs\Webhooks\SendWebhooksJob;
+use App\Events\Sla\SlaBreached;
 use App\Models\Inbox;
 use Carbon\Carbon;
 
@@ -81,7 +81,7 @@ class CheckSlaJob implements ShouldQueue
                     $data['sla_resolution_at'] = $resolutionAt;
                 }
 
-                AppliedSla::updateOrCreate(
+                $appliedSla = AppliedSla::updateOrCreate(
                     ['conversation_id' => $conv->id, 'sla_policy_id' => $policy->id],
                     $data
                 );
@@ -91,8 +91,7 @@ class CheckSlaJob implements ShouldQueue
                 if (! empty($breaches)) {
                     Log::warning('SLA breached', ['conversation_id' => $conv->id, 'policy_id' => $policy->id, 'breaches' => $breaches]);
 
-                    // emit webhook for SLA breach
-                    SendWebhooksJob::dispatch($conv->account_id, 'sla_breached', ['conversation_id' => $conv->id, 'policy_id' => $policy->id, 'breaches' => $breaches]);
+                    event(new SlaBreached($conv, $policy, $breaches, $appliedSla));
                 }
             }
 

--- a/custom/laravel/app/Listeners/HandleArticleUpdated.php
+++ b/custom/laravel/app/Listeners/HandleArticleUpdated.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Listeners;
+
+use App\Events\Article\ArticleUpdated;
+use App\Jobs\Webhooks\SendWebhooksJob;
+use Illuminate\Contracts\Logging\Log as LogContract;
+use function Spatie\Activitylog\activity;
+
+class HandleArticleUpdated
+{
+    public function __construct(private LogContract $log) {}
+
+    public function handle(ArticleUpdated $event): void
+    {
+        $article = $event->article;
+        $eventName = $this->resolveWebhookEvent($event->action);
+
+        SendWebhooksJob::dispatch($article->account_id, $eventName, [
+            'article_id' => $article->id,
+            'portal_id' => $article->portal_id,
+            'action' => $event->action,
+            'previous_status' => $event->previousStatus,
+        ]);
+
+        activity()
+            ->performedOn($article)
+            ->withProperties([
+                'action' => $event->action,
+                'portal_id' => $article->portal_id,
+                'previous_status' => $event->previousStatus,
+            ])
+            ->event($eventName)
+            ->log('Article lifecycle change');
+
+        $this->log->info('Article lifecycle event dispatched', [
+            'article_id' => $article->id,
+            'action' => $event->action,
+        ]);
+    }
+
+    private function resolveWebhookEvent(string $action): string
+    {
+        return match ($action) {
+            'created' => 'article_created',
+            'deleted' => 'article_deleted',
+            'published' => 'article_published',
+            'archived' => 'article_archived',
+            default => 'article_updated',
+        };
+    }
+}

--- a/custom/laravel/app/Listeners/HandleContactCreated.php
+++ b/custom/laravel/app/Listeners/HandleContactCreated.php
@@ -6,6 +6,7 @@ use App\Events\Contact\ContactCreated;
 use App\Jobs\Contacts\SyncContactJob;
 use App\Jobs\Webhooks\SendWebhooksJob;
 use Illuminate\Contracts\Logging\Log as LogContract;
+use function Spatie\Activitylog\activity;
 
 class HandleContactCreated
 {
@@ -20,6 +21,12 @@ class HandleContactCreated
 
         // Emit webhooks for 'contact_created'
         SendWebhooksJob::dispatch($contact->account_id, 'contact_created', ['contact_id' => $contact->id]);
+
+        activity()
+            ->performedOn($contact)
+            ->withProperties(['event' => 'contact_created'])
+            ->event('contact_created')
+            ->log('Contact created');
 
         $this->log->info('HandleContactCreated dispatched side-effects', ['contact_id' => $contact->id]);
     }

--- a/custom/laravel/app/Listeners/HandleContactUpdated.php
+++ b/custom/laravel/app/Listeners/HandleContactUpdated.php
@@ -6,6 +6,7 @@ use App\Events\Contact\ContactUpdated;
 use App\Jobs\Contacts\SyncContactJob;
 use App\Jobs\Webhooks\SendWebhooksJob;
 use Illuminate\Contracts\Logging\Log as LogContract;
+use function Spatie\Activitylog\activity;
 
 class HandleContactUpdated
 {
@@ -20,6 +21,12 @@ class HandleContactUpdated
 
         // Emit webhooks for 'contact_updated'
         SendWebhooksJob::dispatch($contact->account_id, 'contact_updated', ['contact_id' => $contact->id]);
+
+        activity()
+            ->performedOn($contact)
+            ->withProperties(['event' => 'contact_updated'])
+            ->event('contact_updated')
+            ->log('Contact updated');
 
         $this->log->info('HandleContactUpdated dispatched side-effects', ['contact_id' => $contact->id]);
     }

--- a/custom/laravel/app/Listeners/HandleConversationAssigned.php
+++ b/custom/laravel/app/Listeners/HandleConversationAssigned.php
@@ -6,6 +6,7 @@ use App\Events\Conversation\ConversationAssigned;
 use App\Jobs\Conversations\CreateActivityMessageJob;
 use App\Jobs\Webhooks\SendWebhooksJob;
 use Illuminate\Contracts\Logging\Log as LogContract;
+use function Spatie\Activitylog\activity;
 
 class HandleConversationAssigned
 {
@@ -43,6 +44,16 @@ class HandleConversationAssigned
                 $this->log->warning('Failed to notify previous assignee', ['assignee_id' => $event->previousAssignee->id, 'error' => $e->getMessage()]);
             }
         }
+
+        activity()
+            ->performedOn($conversation)
+            ->withProperties([
+                'event' => 'conversation_assigned',
+                'assignee_id' => $assignee?->id,
+                'previous_assignee_id' => $event->previousAssignee?->id,
+            ])
+            ->event('conversation_assigned')
+            ->log('Conversation assignment updated');
 
         $this->log->info('HandleConversationAssigned dispatched side-effects', ['conversation_id' => $conversation->id]);
     }

--- a/custom/laravel/app/Listeners/HandleConversationCreated.php
+++ b/custom/laravel/app/Listeners/HandleConversationCreated.php
@@ -9,6 +9,7 @@ use App\Jobs\Conversations\RunAutoAssignConversationJob;
 use App\Jobs\Conversations\CreateActivityMessageJob;
 use App\Jobs\Webhooks\SendWebhooksJob;
 use Illuminate\Contracts\Logging\Log as LogContract;
+use function Spatie\Activitylog\activity;
 
 class HandleConversationCreated
 {
@@ -32,6 +33,12 @@ class HandleConversationCreated
 
         // 5) Emit webhooks for 'conversation_created'
         SendWebhooksJob::dispatch($conversation->account_id, 'conversation_created', ['conversation_id' => $conversation->id]);
+
+        activity()
+            ->performedOn($conversation)
+            ->withProperties(['event' => 'conversation_created'])
+            ->event('conversation_created')
+            ->log('Conversation created');
 
         $this->log->info('HandleConversationCreated dispatched side-effects', ['conversation_id' => $conversation->id]);
     }

--- a/custom/laravel/app/Listeners/HandleConversationStatusChanged.php
+++ b/custom/laravel/app/Listeners/HandleConversationStatusChanged.php
@@ -9,6 +9,7 @@ use App\Actions\Sla\DispatchSlaTimersAction;
 use App\Jobs\Conversations\CreateActivityMessageJob;
 use App\Jobs\Webhooks\SendWebhooksJob;
 use Illuminate\Contracts\Logging\Log as LogContract;
+use function Spatie\Activitylog\activity;
 
 class HandleConversationStatusChanged
 {
@@ -37,6 +38,16 @@ class HandleConversationStatusChanged
             'previous_status' => $event->previousStatus,
             'new_status' => $event->newStatus,
         ]);
+
+        activity()
+            ->performedOn($conversation)
+            ->withProperties([
+                'event' => 'conversation_status_changed',
+                'previous_status' => $event->previousStatus,
+                'new_status' => $event->newStatus,
+            ])
+            ->event('conversation_status_changed')
+            ->log('Conversation status changed');
 
         $this->log->info('HandleConversationStatusChanged dispatched side-effects', ['conversation_id' => $conversation->id]);
     }

--- a/custom/laravel/app/Listeners/HandleConversationUpdated.php
+++ b/custom/laravel/app/Listeners/HandleConversationUpdated.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Listeners;
+
+use App\Events\Conversation\ConversationUpdated;
+use App\Jobs\Webhooks\SendWebhooksJob;
+use Illuminate\Contracts\Logging\Log as LogContract;
+use function Spatie\Activitylog\activity;
+
+class HandleConversationUpdated
+{
+    public function __construct(private LogContract $log) {}
+
+    public function handle(ConversationUpdated $event): void
+    {
+        $conversation = $event->conversation;
+
+        SendWebhooksJob::dispatch($conversation->account_id, 'conversation_updated', [
+            'conversation_id' => $conversation->id,
+            'changes' => $event->changes,
+        ]);
+
+        activity()
+            ->performedOn($conversation)
+            ->withProperties([
+                'event' => 'conversation_updated',
+                'changes' => $event->changes,
+            ])
+            ->event('conversation_updated')
+            ->log('Conversation updated');
+
+        $this->log->info('HandleConversationUpdated dispatched side-effects', [
+            'conversation_id' => $conversation->id,
+            'changes' => $event->changes,
+        ]);
+    }
+}

--- a/custom/laravel/app/Listeners/HandleMessageLifecycle.php
+++ b/custom/laravel/app/Listeners/HandleMessageLifecycle.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Listeners;
+
+use App\Events\Message\MessageCreated;
+use App\Events\Message\MessageDeleted;
+use App\Events\Message\MessageUpdated;
+use App\Jobs\Webhooks\SendWebhooksJob;
+use Illuminate\Contracts\Logging\Log as LogContract;
+use function Spatie\Activitylog\activity;
+
+class HandleMessageLifecycle
+{
+    public function __construct(private LogContract $log) {}
+
+    public function handle(MessageCreated|MessageUpdated|MessageDeleted $event): void
+    {
+        $message = $event->message;
+
+        $eventName = $this->resolveEventName($event);
+        $payload = [
+            'message_id' => $message->id,
+            'conversation_id' => $message->conversation_id,
+            'account_id' => $message->account_id,
+        ];
+
+        SendWebhooksJob::dispatch($message->account_id, $eventName, $payload);
+
+        activity()
+            ->performedOn($message)
+            ->withProperties([
+                'event' => $eventName,
+                'conversation_id' => $message->conversation_id,
+                'account_id' => $message->account_id,
+            ])
+            ->event($eventName)
+            ->log('Message lifecycle change captured');
+
+        $this->log->info('Handled message lifecycle event', ['event' => $eventName, 'message_id' => $message->id]);
+    }
+
+    private function resolveEventName(MessageCreated|MessageUpdated|MessageDeleted $event): string
+    {
+        return match (true) {
+            $event instanceof MessageCreated => 'message_created',
+            $event instanceof MessageDeleted => 'message_deleted',
+            default => 'message_updated',
+        };
+    }
+}

--- a/custom/laravel/app/Listeners/HandlePortalUpdated.php
+++ b/custom/laravel/app/Listeners/HandlePortalUpdated.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Listeners;
+
+use App\Events\Portal\PortalUpdated;
+use App\Jobs\Webhooks\SendWebhooksJob;
+use Illuminate\Contracts\Logging\Log as LogContract;
+use function Spatie\Activitylog\activity;
+
+class HandlePortalUpdated
+{
+    public function __construct(private LogContract $log) {}
+
+    public function handle(PortalUpdated $event): void
+    {
+        $portal = $event->portal;
+        $eventName = $this->resolveWebhookEvent($event->action);
+
+        SendWebhooksJob::dispatch($portal->account_id, $eventName, [
+            'portal_id' => $portal->id,
+            'action' => $event->action,
+        ]);
+
+        activity()
+            ->performedOn($portal)
+            ->withProperties([
+                'action' => $event->action,
+                'account_id' => $portal->account_id,
+            ])
+            ->event($eventName)
+            ->log('Portal lifecycle change');
+
+        $this->log->info('Portal lifecycle event dispatched', [
+            'portal_id' => $portal->id,
+            'action' => $event->action,
+        ]);
+    }
+
+    private function resolveWebhookEvent(string $action): string
+    {
+        return match ($action) {
+            'created' => 'portal_created',
+            'deleted' => 'portal_deleted',
+            default => 'portal_updated',
+        };
+    }
+}

--- a/custom/laravel/app/Listeners/HandleSlaBreached.php
+++ b/custom/laravel/app/Listeners/HandleSlaBreached.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Listeners;
+
+use App\Events\Sla\SlaBreached;
+use App\Jobs\Webhooks\SendWebhooksJob;
+use Illuminate\Contracts\Logging\Log as LogContract;
+use function Spatie\Activitylog\activity;
+
+class HandleSlaBreached
+{
+    public function __construct(private LogContract $log) {}
+
+    public function handle(SlaBreached $event): void
+    {
+        $conversation = $event->conversation;
+        $payload = [
+            'conversation_id' => $conversation->id,
+            'policy_id' => $event->policy->id,
+            'breaches' => $event->breaches,
+            'applied_sla_id' => $event->appliedSla?->id,
+        ];
+
+        SendWebhooksJob::dispatch($conversation->account_id, 'sla_breached', $payload);
+
+        activity()
+            ->performedOn($conversation)
+            ->withProperties([
+                'policy_id' => $event->policy->id,
+                'breaches' => $event->breaches,
+                'applied_sla_id' => $event->appliedSla?->id,
+            ])
+            ->event('sla_breached')
+            ->log('SLA breach detected');
+
+        $this->log->warning('SLA breach recorded', [
+            'conversation_id' => $conversation->id,
+            'policy_id' => $event->policy->id,
+            'breaches' => $event->breaches,
+        ]);
+    }
+}

--- a/custom/laravel/app/Providers/EventServiceProvider.php
+++ b/custom/laravel/app/Providers/EventServiceProvider.php
@@ -5,17 +5,27 @@ namespace App\Providers;
 use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvider;
 use App\Events\Message\MessageCreated;
 use App\Events\Message\MessageUpdated;
+use App\Events\Message\MessageDeleted;
 use App\Events\Conversation\ConversationCreated;
 use App\Events\Conversation\ConversationAssigned;
 use App\Events\Conversation\ConversationStatusChanged;
+use App\Events\Conversation\ConversationUpdated;
 use App\Events\Contact\ContactCreated;
 use App\Events\Contact\ContactUpdated;
+use App\Events\Sla\SlaBreached;
+use App\Events\Portal\PortalUpdated;
+use App\Events\Article\ArticleUpdated;
 use App\Listeners\EnqueueOpenAiEnrichment;
 use App\Listeners\HandleConversationCreated;
 use App\Listeners\HandleConversationAssigned;
 use App\Listeners\HandleConversationStatusChanged;
+use App\Listeners\HandleConversationUpdated;
 use App\Listeners\HandleContactCreated;
 use App\Listeners\HandleContactUpdated;
+use App\Listeners\HandleMessageLifecycle;
+use App\Listeners\HandleSlaBreached;
+use App\Listeners\HandlePortalUpdated;
+use App\Listeners\HandleArticleUpdated;
 
 class EventServiceProvider extends ServiceProvider
 {
@@ -27,10 +37,15 @@ class EventServiceProvider extends ServiceProvider
     protected $listen = [
         MessageCreated::class => [
             EnqueueOpenAiEnrichment::class,
+            HandleMessageLifecycle::class,
         ],
         // Also process updates to messages (reuse enrichment listener)
         MessageUpdated::class => [
             EnqueueOpenAiEnrichment::class,
+            HandleMessageLifecycle::class,
+        ],
+        MessageDeleted::class => [
+            HandleMessageLifecycle::class,
         ],
 
         ConversationCreated::class => [
@@ -45,12 +60,28 @@ class EventServiceProvider extends ServiceProvider
             HandleConversationStatusChanged::class,
         ],
 
+        ConversationUpdated::class => [
+            HandleConversationUpdated::class,
+        ],
+
         ContactCreated::class => [
             HandleContactCreated::class,
         ],
 
         ContactUpdated::class => [
             HandleContactUpdated::class,
+        ],
+
+        SlaBreached::class => [
+            HandleSlaBreached::class,
+        ],
+
+        PortalUpdated::class => [
+            HandlePortalUpdated::class,
+        ],
+
+        ArticleUpdated::class => [
+            HandleArticleUpdated::class,
         ],
     ];
 

--- a/custom/laravel/routes/channels.php
+++ b/custom/laravel/routes/channels.php
@@ -40,3 +40,30 @@ Broadcast::channel('account.{accountId}.presence', function ($user, $accountId) 
 
     return false;
 });
+
+// User-specific private channel for direct assignment/notifications
+Broadcast::channel('user.{userId}', function ($user, $userId) {
+    return (int) $user->id === (int) $userId;
+});
+
+// Portal channel - scoped to account membership
+Broadcast::channel('portal.{portalId}', function ($user, $portalId) {
+    $portal = \App\Models\Portal::find($portalId);
+
+    if (! $portal) {
+        return false;
+    }
+
+    return $user->accounts()->where('account_id', $portal->account_id)->exists();
+});
+
+// Article channel - scoped to account membership via portal/account
+Broadcast::channel('article.{articleId}', function ($user, $articleId) {
+    $article = \App\Models\Article::find($articleId);
+
+    if (! $article) {
+        return false;
+    }
+
+    return $user->accounts()->where('account_id', $article->account_id)->exists();
+});

--- a/custom/laravel/routes/channels.php
+++ b/custom/laravel/routes/channels.php
@@ -1,5 +1,8 @@
 <?php
 
+use App\Models\Article;
+use App\Models\Conversation;
+use App\Models\Portal;
 use Illuminate\Support\Facades\Broadcast;
 
 /*
@@ -20,7 +23,7 @@ Broadcast::channel('account.{accountId}', function ($user, $accountId) {
 
 // Conversation channel - for specific conversation updates
 Broadcast::channel('conversation.{conversationId}', function ($user, $conversationId) {
-    $conversation = \App\Models\Conversation::find($conversationId);
+    $conversation = Conversation::find($conversationId);
     if (! $conversation) {
         return false;
     }
@@ -48,7 +51,7 @@ Broadcast::channel('user.{userId}', function ($user, $userId) {
 
 // Portal channel - scoped to account membership
 Broadcast::channel('portal.{portalId}', function ($user, $portalId) {
-    $portal = \App\Models\Portal::find($portalId);
+    $portal = Portal::find($portalId);
 
     if (! $portal) {
         return false;
@@ -59,7 +62,7 @@ Broadcast::channel('portal.{portalId}', function ($user, $portalId) {
 
 // Article channel - scoped to account membership via portal/account
 Broadcast::channel('article.{articleId}', function ($user, $articleId) {
-    $article = \App\Models\Article::find($articleId);
+    $article = Article::find($articleId);
 
     if (! $article) {
         return false;


### PR DESCRIPTION
## Summary
- add Laravel events and listeners for conversation/message lifecycle, SLA breaches, and contact assignment updates with activity logging and webhooks
- broadcast portal and article lifecycle changes using new resources and guarded channels for Reverb
- wire controllers/actions to dispatch lifecycle events across public/widget flows and refresh task log status

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_695489fd3470832abfa32b25e3bb0769)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Real-time broadcasts for conversations, messages, contacts, articles, portals, and SLA breaches with new scoped channels
  * Event-driven lifecycle notifications + webhook dispatch for create/update/delete across entities
  * Standardized API resources for articles and portals to unify responses
  * Centralized activity/audit logging for conversation/message/contact/article/portal events

* **Documentation**
  * Task checklist updated for events, listeners, broadcasting and audit parity

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->