### PR TITLE
feat(seeding): add demo login and report seed data

### DIFF
--- a/laravel-svelte-port/laravel/database/seeders/DatabaseSeeder.php
+++ b/laravel-svelte-port/laravel/database/seeders/DatabaseSeeder.php
@@ -26,5 +26,6 @@ class DatabaseSeeder extends Seeder
         $this->call(\Database\Seeders\RolesAndPermissionsSeeder::class);
         $this->call(InstallationConfigSeeder::class);
         $this->call(OnboardingFlagSeeder::class);
+        $this->call(DemoReportsSeeder::class);
     }
 }

--- a/laravel-svelte-port/laravel/database/seeders/DemoReportsSeeder.php
+++ b/laravel-svelte-port/laravel/database/seeders/DemoReportsSeeder.php
@@ -1,0 +1,207 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Enums\AccountUserRole;
+use App\Models\Account;
+use App\Models\AccountUser;
+use App\Models\Conversation;
+use App\Models\CsatSurveyResponse;
+use App\Models\Message;
+use App\Models\ReportingEvent;
+use App\Models\User;
+use App\Services\Seeding\AccountSeederService;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\Hash;
+
+class DemoReportsSeeder extends Seeder
+{
+    /**
+     * Seed deterministic data for login and reports verification.
+     */
+    public function run(): void
+    {
+        $demoAccount = Account::query()->firstOrCreate(
+            ['name' => 'Demo Reports Account'],
+            [
+                'locale' => 'en',
+                'domain' => 'demo-reports.local',
+                'support_email' => 'support@demo-reports.local',
+                'settings' => [],
+                'feature_flags' => 32128855,
+                'limits' => ['agents' => 100, 'inboxes' => 50],
+            ]
+        );
+
+        (new AccountSeederService($demoAccount))->perform();
+
+        $demoUser = User::query()->updateOrCreate(
+            ['email' => 'mdriaz@alpha.net.bd'],
+            [
+                'name' => 'Demo Reports Admin',
+                'password' => Hash::make('12345678'),
+                'type' => 'User',
+                'email_verified_at' => now(),
+            ]
+        );
+
+        AccountUser::query()->updateOrCreate(
+            [
+                'account_id' => $demoAccount->id,
+                'user_id' => $demoUser->id,
+            ],
+            [
+                'role' => AccountUserRole::ADMINISTRATOR,
+            ]
+        );
+        $this->seedReportingEvents($demoAccount->id);
+        $this->seedCsatResponses($demoAccount->id);
+    }
+
+    /**
+     * Create report-friendly analytics events used by summary and heatmap APIs.
+     */
+    private function seedReportingEvents(int $accountId): void
+    {
+        ReportingEvent::query()->where('account_id', $accountId)->delete();
+
+        $conversations = Conversation::query()
+            ->where('account_id', $accountId)
+            ->with('messages:id,conversation_id,message_type,created_at')
+            ->get();
+
+        foreach ($conversations as $index => $conversation) {
+            $openedAt = now()->subDays(14 - ($index % 10))->startOfDay()->addHours(9 + ($index % 6));
+            $assignedUserId = $conversation->assignee_id;
+
+            $this->createEvent(
+                accountId: $accountId,
+                conversationId: $conversation->id,
+                inboxId: $conversation->inbox_id,
+                userId: $assignedUserId,
+                name: 'conversation_opened',
+                value: 1,
+                eventTime: $openedAt
+            );
+
+            $messageTypes = $conversation->messages->pluck('message_type')->all();
+            $incomingCount = count(array_filter($messageTypes, fn (int $type) => $type === Message::TYPE_INCOMING));
+            $outgoingCount = count(array_filter($messageTypes, fn (int $type) => $type === Message::TYPE_OUTGOING));
+
+            for ($i = 0; $i < max(1, $incomingCount); $i++) {
+                $this->createEvent(
+                    accountId: $accountId,
+                    conversationId: $conversation->id,
+                    inboxId: $conversation->inbox_id,
+                    userId: $assignedUserId,
+                    name: 'message_created',
+                    value: Message::TYPE_INCOMING,
+                    eventTime: $openedAt->copy()->addMinutes(5 + $i)
+                );
+            }
+
+            for ($i = 0; $i < max(1, $outgoingCount); $i++) {
+                $this->createEvent(
+                    accountId: $accountId,
+                    conversationId: $conversation->id,
+                    inboxId: $conversation->inbox_id,
+                    userId: $assignedUserId,
+                    name: 'message_created',
+                    value: Message::TYPE_OUTGOING,
+                    eventTime: $openedAt->copy()->addMinutes(12 + $i)
+                );
+            }
+
+            $firstResponseSeconds = 180 + (($index % 5) * 45);
+            $resolutionSeconds = 1200 + (($index % 7) * 240);
+            $replySeconds = 140 + (($index % 4) * 30);
+
+            $this->createEvent(
+                accountId: $accountId,
+                conversationId: $conversation->id,
+                inboxId: $conversation->inbox_id,
+                userId: $assignedUserId,
+                name: 'first_response',
+                value: $firstResponseSeconds,
+                eventTime: $openedAt->copy()->addMinutes(8)
+            );
+
+            $this->createEvent(
+                accountId: $accountId,
+                conversationId: $conversation->id,
+                inboxId: $conversation->inbox_id,
+                userId: $assignedUserId,
+                name: 'reply_time',
+                value: $replySeconds,
+                eventTime: $openedAt->copy()->addMinutes(10)
+            );
+
+            $this->createEvent(
+                accountId: $accountId,
+                conversationId: $conversation->id,
+                inboxId: $conversation->inbox_id,
+                userId: $assignedUserId,
+                name: 'conversation_resolved',
+                value: $resolutionSeconds,
+                eventTime: $openedAt->copy()->addMinutes(40)
+            );
+        }
+    }
+
+    private function createEvent(
+        int $accountId,
+        int $conversationId,
+        int $inboxId,
+        ?int $userId,
+        string $name,
+        float|int $value,
+        \Illuminate\Support\Carbon $eventTime
+    ): void {
+        ReportingEvent::query()->create([
+            'account_id' => $accountId,
+            'conversation_id' => $conversationId,
+            'inbox_id' => $inboxId,
+            'user_id' => $userId,
+            'name' => $name,
+            'value' => $value,
+            'value_in_business_hours' => $value,
+            'event_start_time' => $eventTime,
+            'event_end_time' => $eventTime,
+            'created_at' => $eventTime,
+            'updated_at' => $eventTime,
+        ]);
+    }
+
+    /**
+     * Seed CSAT rows so the CSAT report has realistic prefilled data.
+     */
+    private function seedCsatResponses(int $accountId): void
+    {
+        CsatSurveyResponse::query()->where('account_id', $accountId)->delete();
+
+        $conversations = Conversation::query()
+            ->where('account_id', $accountId)
+            ->with(['messages:id,conversation_id,created_at', 'contact:id'])
+            ->take(8)
+            ->get();
+
+        foreach ($conversations as $index => $conversation) {
+            $lastMessage = $conversation->messages->sortByDesc('created_at')->first();
+            if (! $lastMessage) {
+                continue;
+            }
+
+            CsatSurveyResponse::query()->create([
+                'account_id' => $accountId,
+                'conversation_id' => $conversation->id,
+                'message_id' => $lastMessage->id,
+                'contact_id' => $conversation->contact_id,
+                'assigned_agent_id' => $conversation->assignee_id,
+                'rating' => ($index % 5) + 1,
+                'feedback_message' => 'Seeded CSAT feedback for migration parity checks.',
+                'created_at' => now()->subDays(8 - $index),
+                'updated_at' => now()->subDays(8 - $index),
+            ]);
+        }
+    }
+}

--- a/laravel-svelte-port/laravel/database/seeders/OnboardingFlagSeeder.php
+++ b/laravel-svelte-port/laravel/database/seeders/OnboardingFlagSeeder.php
@@ -3,15 +3,24 @@
 namespace Database\Seeders;
 
 use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\Cache;
 
 class OnboardingFlagSeeder extends Seeder
 {
     /**
-     * Set the Redis onboarding flag for first-time superadmin creation.
+     * Set the onboarding flag for first-time superadmin creation.
      */
     public function run(): void
     {
-        // Set the onboarding flag in Redis (Rails-style)
-        app('redis')->set('chatwoot_installation_onboarding', true);
+        if (! class_exists(\Redis::class) && ! class_exists(\Predis\Client::class)) {
+            Cache::forever('chatwoot_installation_onboarding', true);
+            return;
+        }
+
+        try {
+            app('redis')->set('chatwoot_installation_onboarding', true);
+        } catch (\Throwable) {
+            Cache::forever('chatwoot_installation_onboarding', true);
+        }
     }
 }


### PR DESCRIPTION
### Motivation
- Provide a deterministic demo dataset to validate migrated reports and allow login using the default credentials prefilled on the Svelte login page.
- Avoid local seeding failures when Redis is unavailable during onboarding seeding.

### Description
- Added a new seeder `DemoReportsSeeder` which creates a demo account, a demo admin user (`mdriaz@alpha.net.bd` / `12345678`), runs the existing `AccountSeederService` for account entities, seeds reporting events (`conversation_opened`, `message_created`, `first_response`, `reply_time`, `conversation_resolved`) and CSAT responses to populate report pages.
- Wired `DemoReportsSeeder` into `DatabaseSeeder` so `php artisan migrate:fresh --seed` provides a login-ready dataset.
- Hardened `OnboardingFlagSeeder` to fall back to `Cache::forever()` when Redis/Predis is not available and to catch errors when setting the Redis flag.
- No changes to Svelte UI files besides relying on the existing login defaults; the seeder aligns credentials with the login page defaults.

### Testing
- Lint checks: ran `php -l` on `DatabaseSeeder.php`, `OnboardingFlagSeeder.php`, and `DemoReportsSeeder.php` (all succeeded).
- Database flow: ran `php artisan migrate:fresh --seed --force` which completed successfully and confirmed seeded data exists via `php artisan tinker` showing the demo user and seeded counts (`reporting_events=54`, `csat_responses=8`).
- Frontend run: started Svelte dev server and attempted automated browser walkthrough; captured a prefilled login screenshot successfully, and captured evidence of a CORS/preflight block during automated login→reports navigation in this environment (CORS configured and fixed on backend during run, but browser environment had transient preflight behavior). Screenshots captured as proof artifacts during validation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_698c9a26b228832aa00fb2e5f6404121)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive demo data seeding for test environments, including reporting events and customer satisfaction survey responses to support analytics testing and verification workflows.

* **Improvements**
  * Strengthened onboarding reliability with automatic fallback from Redis to cache when Redis is unavailable, ensuring consistent setup across different infrastructure configurations and deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->