### PR TITLE
refactor(seeding): align laravel account seed data with rails parity

### DIFF
--- a/laravel-svelte-port/REPORTS_SCREENSHOT_LOG.md
+++ b/laravel-svelte-port/REPORTS_SCREENSHOT_LOG.md
@@ -6,8 +6,8 @@ This update addresses review feedback to take screenshots by logging in and visi
 
 - Backend: `php artisan serve --host=0.0.0.0 --port=8000`
 - Frontend: `npm run dev -- --host 0.0.0.0 --port 5173`
-- Login: `mdriaz@alpha.net.bd` / `12345678`
-- Account: `1`
+- Login: `<REDACTED_EMAIL>` / `<REDACTED_PASSWORD>`
+- Account: `<REDACTED_ACCOUNT_ID>`
 
 ## Menu-by-menu screenshots
 

--- a/laravel-svelte-port/REPORTS_SCREENSHOT_LOG.md
+++ b/laravel-svelte-port/REPORTS_SCREENSHOT_LOG.md
@@ -1,0 +1,24 @@
+# Reports UI Screenshot Log
+
+This update addresses review feedback to take screenshots by logging in and visiting each Reports menu page one by one.
+
+## Environment
+
+- Backend: `php artisan serve --host=0.0.0.0 --port=8000`
+- Frontend: `npm run dev -- --host 0.0.0.0 --port 5173`
+- Login: `mdriaz@alpha.net.bd` / `12345678`
+- Account: `1`
+
+## Menu-by-menu screenshots
+
+1. Overview: `reports-menu-walk-overview.png`
+2. Conversation: `reports-menu-walk-conversation.png`
+3. Agent: `reports-menu-walk-agent.png`
+4. Label: `reports-menu-walk-label.png`
+5. Inbox: `reports-menu-walk-inbox.png`
+6. Team: `reports-menu-walk-team.png`
+7. CSAT: `reports-menu-walk-csat.png`
+8. SLA: `reports-menu-walk-sla.png`
+9. Bot: `reports-menu-walk-bot.png`
+
+All screenshots were captured in a logged-in session and navigated through the Reports sidebar links.

--- a/laravel-svelte-port/laravel/app/DataTransferObjects/SeedData.php
+++ b/laravel-svelte-port/laravel/app/DataTransferObjects/SeedData.php
@@ -33,6 +33,72 @@ class SeedData extends Data
         );
     }
 
+    private static function getDefaultTeams(): array
+    {
+        return [
+            '💰 Sales',
+            '💼 Management',
+            '👩‍💼 Administration',
+            '🚛 Warehouse',
+        ];
+    }
+
+    private static function getDefaultCustomRoles(): array
+    {
+        return [
+            [
+                'name' => 'Customer Support Lead',
+                'description' => 'Lead support agent with full conversation and contact management',
+                'permissions' => [
+                    'conversation_manage',
+                    'contact_manage',
+                    'report_manage',
+                ],
+            ],
+            [
+                'name' => 'Sales Representative',
+                'description' => 'Sales team member with conversation and contact access',
+                'permissions' => [
+                    'conversation_unassigned_manage',
+                    'conversation_participating_manage',
+                    'contact_manage',
+                ],
+            ],
+            [
+                'name' => 'Knowledge Manager',
+                'description' => 'Manages knowledge base and participates in conversations',
+                'permissions' => [
+                    'knowledge_base_manage',
+                    'conversation_participating_manage',
+                ],
+            ],
+            [
+                'name' => 'Junior Agent',
+                'description' => 'Entry-level agent with basic conversation access',
+                'permissions' => [
+                    'conversation_participating_manage',
+                ],
+            ],
+            [
+                'name' => 'Analytics Specialist',
+                'description' => 'Focused on reports and data analysis',
+                'permissions' => [
+                    'report_manage',
+                    'conversation_participating_manage',
+                ],
+            ],
+            [
+                'name' => 'Escalation Handler',
+                'description' => 'Handles unassigned conversations and escalations',
+                'permissions' => [
+                    'conversation_unassigned_manage',
+                    'conversation_participating_manage',
+                    'contact_manage',
+                ],
+            ],
+        ];
+    }
+
     private static function getDefaultUsers(): array
     {
         return [
@@ -40,7 +106,7 @@ class SeedData extends Data
                 'name' => 'Michael Scott',
                 'gender' => 'male',
                 'email' => 'michael_scott@paperlayer.test',
-                'teams' => ['sales', 'management', 'administration', 'warehouse'],
+                'teams' => ['Sales', 'Management', 'Administration', 'Warehouse'],
                 'role' => 'administrator',
             ],
             [
@@ -74,251 +140,59 @@ class SeedData extends Data
                 'teams' => ['Management'],
             ],
             [
-                'name' => 'Ed Truck',
-                'gender' => 'male',
-                'email' => 'ed@paperlayer.test',
-                'teams' => ['Management'],
-            ],
-            [
-                'name' => 'Dan Gore',
-                'gender' => 'male',
-                'email' => 'dan@paperlayer.test',
-                'teams' => ['Management'],
-            ],
-            [
-                'name' => 'Craig D',
-                'gender' => 'male',
-                'email' => 'craig@paperlayer.test',
-                'teams' => ['Sales'],
-            ],
-            [
-                'name' => 'Jim Halpert',
-                'gender' => 'male',
-                'email' => 'jim@paperlayer.test',
+                'name' => 'Karen Filippelli',
+                'gender' => 'female',
+                'email' => 'karn@paperlayer.test',
                 'teams' => ['Sales'],
                 'custom_role' => 'Sales Representative',
             ],
             [
-                'name' => 'Dwight Schrute',
+                'name' => 'Danny Cordray',
                 'gender' => 'male',
-                'email' => 'dwight@paperlayer.test',
+                'email' => 'danny@paperlayer.test',
                 'teams' => ['Sales'],
-                'custom_role' => 'Assistant Regional Manager',
+                'custom_role' => 'Customer Support Lead',
             ],
             [
-                'name' => 'Pam Beesly',
-                'gender' => 'female',
-                'email' => 'pam@paperlayer.test',
-                'teams' => ['Administration'],
-                'custom_role' => 'Receptionist',
-            ],
-            [
-                'name' => 'Stanley Hudson',
+                'name' => 'Ben Nugent',
                 'gender' => 'male',
-                'email' => 'stanley@paperlayer.test',
+                'email' => 'ben@paperlayer.test',
                 'teams' => ['Sales'],
+                'custom_role' => 'Junior Agent',
             ],
             [
-                'name' => 'Kevin Malone',
-                'gender' => 'male',
-                'email' => 'kevin@paperlayer.test',
-                'teams' => ['Administration'],
-            ],
-            [
-                'name' => 'Angela Martin',
+                'name' => 'Cathy Simms',
                 'gender' => 'female',
-                'email' => 'angela@paperlayer.test',
+                'email' => 'cathy@paperlayer.test',
                 'teams' => ['Administration'],
+                'custom_role' => 'Knowledge Manager',
             ],
             [
-                'name' => 'Oscar Martinez',
+                'name' => 'Hunter Jo',
                 'gender' => 'male',
-                'email' => 'oscar@paperlayer.test',
+                'email' => 'hunter@paperlayer.test',
                 'teams' => ['Administration'],
+                'custom_role' => 'Analytics Specialist',
             ],
             [
-                'name' => 'Phyllis Vance',
+                'name' => 'Stephanie Wilson',
                 'gender' => 'female',
-                'email' => 'phyllis@paperlayer.test',
-                'teams' => ['Sales'],
-            ],
-            [
-                'name' => 'Meredith Palmer',
-                'gender' => 'female',
-                'email' => 'meredith@paperlayer.test',
+                'email' => 'stephanie@paperlayer.test',
                 'teams' => ['Administration'],
+                'custom_role' => 'Escalation Handler',
             ],
             [
-                'name' => 'Creed Bratton',
-                'gender' => 'male',
-                'email' => 'creed@paperlayer.test',
-                'teams' => ['Administration'],
-            ],
-            [
-                'name' => 'Kelly Kapoor',
+                'name' => 'Lonny Collins',
                 'gender' => 'female',
-                'email' => 'kelly@paperlayer.test',
-                'teams' => ['Administration'],
-            ],
-            [
-                'name' => 'Ryan Howard',
-                'gender' => 'male',
-                'email' => 'ryan@paperlayer.test',
-                'teams' => ['Sales'],
-            ],
-            [
-                'name' => 'Toby Flenderson',
-                'gender' => 'male',
-                'email' => 'toby@paperlayer.test',
-                'teams' => ['Administration'],
-            ],
-            [
-                'name' => 'Andy Bernard',
-                'gender' => 'male',
-                'email' => 'andy@paperlayer.test',
-                'teams' => ['Sales'],
-            ],
-            [
-                'name' => 'Erin Hannon',
-                'gender' => 'female',
-                'email' => 'erin@paperlayer.test',
-                'teams' => ['Administration'],
-            ],
-            [
-                'name' => 'Gabe Lewis',
-                'gender' => 'male',
-                'email' => 'gabe@paperlayer.test',
-                'teams' => ['Management'],
-            ],
-            [
-                'name' => 'Holly Flax',
-                'gender' => 'female',
-                'email' => 'holly@paperlayer.test',
-                'teams' => ['Administration'],
-            ],
-            [
-                'name' => 'Todd Packer',
-                'gender' => 'male',
-                'email' => 'todd@paperlayer.test',
-                'teams' => ['Sales'],
-            ],
-            [
-                'name' => 'Jan Levinson',
-                'gender' => 'female',
-                'email' => 'jan@paperlayer.test',
-                'teams' => ['Management'],
-            ],
-            [
-                'name' => 'Karen Filippelli',
-                'gender' => 'female',
-                'email' => 'karen@paperlayer.test',
-                'teams' => ['Sales'],
-            ],
-            [
-                'name' => 'Robert California',
-                'gender' => 'male',
-                'email' => 'robert@paperlayer.test',
-                'teams' => ['Management'],
-            ],
-            [
-                'name' => 'Nellie Bertram',
-                'gender' => 'female',
-                'email' => 'nellie@paperlayer.test',
-                'teams' => ['Management'],
-            ],
-            [
-                'name' => 'Pete Miller',
-                'gender' => 'male',
-                'email' => 'pete@paperlayer.test',
-                'teams' => ['Sales'],
-            ],
-            [
-                'name' => 'Clark Green',
-                'gender' => 'male',
-                'email' => 'clark@paperlayer.test',
-                'teams' => ['Sales'],
-            ],
-            [
-                'name' => 'Nate Nickerson',
-                'gender' => 'male',
-                'email' => 'nate@paperlayer.test',
+                'email' => 'lonny@paperlayer.test',
                 'teams' => ['Warehouse'],
+                'custom_role' => 'Customer Support Lead',
             ],
             [
-                'name' => 'Darryl Philbin',
-                'gender' => 'male',
-                'email' => 'darryl@paperlayer.test',
+                'name' => 'Madge Madsen',
+                'gender' => 'female',
+                'email' => 'madge@paperlayer.test',
                 'teams' => ['Warehouse'],
-            ],
-        ];
-    }
-
-    private static function getDefaultTeams(): array
-    {
-        return [
-            '📈 Sales',
-            '👔 Management', 
-            '📋 Administration',
-            '📦 Warehouse',
-        ];
-    }
-
-    private static function getDefaultCustomRoles(): array
-    {
-        return [
-            [
-                'name' => 'Customer Support Lead',
-                'description' => 'Lead customer support operations and manage escalations',
-                'permissions' => [
-                    'conversation_manage',
-                    'contact_manage',
-                    'report_manage',
-                    'team_manage',
-                ],
-            ],
-            [
-                'name' => 'Sales Representative',
-                'description' => 'Handle sales inquiries and manage customer relationships',
-                'permissions' => [
-                    'conversation_participating_manage',
-                    'contact_manage',
-                ],
-            ],
-            [
-                'name' => 'Technical Support Specialist',
-                'description' => 'Provide technical assistance and troubleshooting',
-                'permissions' => [
-                    'conversation_manage',
-                    'contact_manage',
-                    'knowledge_base_manage',
-                ],
-            ],
-            [
-                'name' => 'Assistant Regional Manager',
-                'description' => 'Assist in regional management and operations',
-                'permissions' => [
-                    'conversation_manage',
-                    'contact_manage',
-                    'report_manage',
-                ],
-            ],
-            [
-                'name' => 'Receptionist',
-                'description' => 'Handle initial customer contact and routing',
-                'permissions' => [
-                    'conversation_unassigned_manage',
-                    'contact_manage',
-                ],
-            ],
-            [
-                'name' => 'Quality Assurance Manager',
-                'description' => 'Monitor and ensure service quality standards',
-                'permissions' => [
-                    'conversation_manage',
-                    'contact_manage',
-                    'report_manage',
-                    'audit_manage',
-                ],
             ],
         ];
     }
@@ -327,33 +201,33 @@ class SeedData extends Data
     {
         return [
             [
-                'title' => 'Bug',
-                'color' => '#FF6B6B',
+                'title' => 'billing',
+                'color' => '#28AD21',
                 'show_on_sidebar' => true,
             ],
             [
-                'title' => 'Feature Request',
-                'color' => '#4ECDC4',
+                'title' => 'software',
+                'color' => '#8F6EF2',
                 'show_on_sidebar' => true,
             ],
             [
-                'title' => 'Priority',
-                'color' => '#45B7D1',
+                'title' => 'delivery',
+                'color' => '#A2FDD5',
                 'show_on_sidebar' => true,
             ],
             [
-                'title' => 'Sales',
-                'color' => '#96CEB4',
+                'title' => 'ops-handover',
+                'color' => '#A53326',
                 'show_on_sidebar' => true,
             ],
             [
-                'title' => 'Support',
-                'color' => '#FFEAA7',
+                'title' => 'premium-customer',
+                'color' => '#6FD4EF',
                 'show_on_sidebar' => true,
             ],
             [
-                'title' => 'Billing',
-                'color' => '#DDA0DD',
+                'title' => 'lead',
+                'color' => '#F161C8',
                 'show_on_sidebar' => true,
             ],
         ];
@@ -363,220 +237,202 @@ class SeedData extends Data
     {
         return [
             [
-                'name' => 'John Customer',
-                'email' => 'john@customer.com',
-                'conversations' => [
-                    [
-                        'channel' => 'WebWidget',
-                        'source_id' => 'web_001',
-                        'assignee' => 'jim@paperlayer.test',
-                        'priority' => 'medium',
-                        'labels' => ['Support'],
-                        'messages' => [
-                            [
-                                'content' => 'Hi, I need help with my account setup.',
-                                'message_type' => 'incoming',
-                            ],
-                            [
-                                'content' => 'Hello! I\'d be happy to help you with your account setup. What specific issue are you experiencing?',
-                                'message_type' => 'outgoing',
-                                'sender' => 'jim@paperlayer.test',
-                            ],
+                'name' => 'Lorrie Trosdall',
+                'email' => 'ltrosdall0@bravesites.test',
+                'conversations' => [[
+                    'channel' => 'WebWidget',
+                    'source_id' => 'web_001',
+                    'assignee' => 'michael_scott@paperlayer.test',
+                    'priority' => 'medium',
+                    'labels' => ['software'],
+                    'messages' => [
+                        [
+                            'content' => "Hi, I'm having trouble logging in to my account.",
+                            'message_type' => 'incoming',
+                        ],
+                        [
+                            'content' => 'Hi! Sorry to hear that. Can you please provide me with your username and email address so I can look into it for you?',
+                            'message_type' => 'outgoing',
+                            'sender' => 'michael_scott@paperlayer.test',
                         ],
                     ],
-                ],
+                ]],
             ],
             [
-                'name' => 'Sarah Johnson',
-                'email' => 'sarah@example.com',
-                'conversations' => [
-                    [
-                        'channel' => 'FacebookPage',
-                        'source_id' => 'fb_002',
-                        'assignee' => 'pam@paperlayer.test',
-                        'priority' => 'high',
-                        'labels' => ['Sales', 'Priority'],
-                        'messages' => [
-                            [
-                                'content' => 'I\'m interested in your premium plan. Can you tell me more about the features?',
-                                'message_type' => 'incoming',
-                            ],
-                            [
-                                'content' => 'Absolutely! Our premium plan includes advanced reporting, custom roles, and priority support. Would you like me to schedule a demo?',
-                                'message_type' => 'outgoing',
-                                'sender' => 'pam@paperlayer.test',
-                            ],
+                'name' => 'Tiffanie Cloughton',
+                'email' => 'tcloughton1@newyorker.test',
+                'conversations' => [[
+                    'channel' => 'FacebookPage',
+                    'source_id' => 'fb_002',
+                    'assignee' => 'karn@paperlayer.test',
+                    'priority' => 'high',
+                    'labels' => ['billing', 'premium-customer'],
+                    'messages' => [
+                        [
+                            'content' => 'Hi, I need some help with my billing statement.',
+                            'message_type' => 'incoming',
+                        ],
+                        [
+                            'content' => "Hello! I'd be happy to assist you with that. Can you please tell me which billing statement you're referring to?",
+                            'message_type' => 'outgoing',
+                            'sender' => 'michael_scott@paperlayer.test',
                         ],
                     ],
-                ],
+                ]],
             ],
             [
-                'name' => 'Mike Wilson',
-                'email' => 'mike@techcorp.com',
-                'conversations' => [
-                    [
-                        'channel' => 'Email',
-                        'source_id' => 'email_003',
-                        'assignee' => 'dwight@paperlayer.test',
-                        'priority' => 'low',
-                        'labels' => ['Bug'],
-                        'messages' => [
-                            [
-                                'content' => 'I found a bug in the reporting dashboard. The export function is not working.',
-                                'message_type' => 'incoming',
-                            ],
-                            [
-                                'content' => 'Thank you for reporting this issue. I\'ve escalated it to our development team and will keep you updated on the progress.',
-                                'message_type' => 'outgoing',
-                                'sender' => 'dwight@paperlayer.test',
-                            ],
+                'name' => 'Mikel Kipple',
+                'email' => 'mkipple2@marriott.test',
+                'conversations' => [[
+                    'channel' => 'TwitterProfile',
+                    'source_id' => 'tw_003',
+                    'assignee' => 'danny@paperlayer.test',
+                    'priority' => 'low',
+                    'labels' => ['lead'],
+                    'messages' => [
+                        [
+                            'content' => 'I have a question about your enterprise plan pricing.',
+                            'message_type' => 'incoming',
+                        ],
+                        [
+                            'content' => 'Happy to help. I can walk you through enterprise pricing and available onboarding support.',
+                            'message_type' => 'outgoing',
+                            'sender' => 'danny@paperlayer.test',
                         ],
                     ],
-                ],
+                ]],
             ],
             [
-                'name' => 'Lisa Chen',
-                'email' => 'lisa@startup.io',
-                'conversations' => [
-                    [
-                        'channel' => 'TwitterProfile',
-                        'source_id' => 'tw_004',
-                        'assignee' => 'stanley@paperlayer.test',
-                        'priority' => 'medium',
-                        'labels' => ['Feature Request'],
-                        'messages' => [
-                            [
-                                'content' => 'Would love to see integration with Slack for our team notifications!',
-                                'message_type' => 'incoming',
-                            ],
-                            [
-                                'content' => 'Great suggestion! Slack integration is actually available in our current version. I can help you set it up.',
-                                'message_type' => 'outgoing',
-                                'sender' => 'stanley@paperlayer.test',
-                            ],
+                'name' => 'Shae Wallis',
+                'email' => 'swallis3@washingtonpost.test',
+                'conversations' => [[
+                    'channel' => 'Whatsapp',
+                    'source_id' => 'wa_004',
+                    'assignee' => 'stephanie@paperlayer.test',
+                    'priority' => 'urgent',
+                    'labels' => ['ops-handover'],
+                    'messages' => [
+                        [
+                            'content' => 'Our team needs urgent help with handover before shift change.',
+                            'message_type' => 'incoming',
+                        ],
+                        [
+                            'content' => "Thanks for flagging this. I'm escalating immediately and sharing a clear handover checklist.",
+                            'message_type' => 'outgoing',
+                            'sender' => 'stephanie@paperlayer.test',
                         ],
                     ],
-                ],
+                ]],
             ],
             [
-                'name' => 'David Rodriguez',
-                'email' => 'david@agency.com',
-                'conversations' => [
-                    [
-                        'channel' => 'Whatsapp',
-                        'source_id' => 'wa_005',
-                        'assignee' => 'angela@paperlayer.test',
-                        'priority' => 'high',
-                        'labels' => ['Billing', 'Priority'],
-                        'messages' => [
-                            [
-                                'content' => 'I have a question about my billing. The invoice seems incorrect.',
-                                'message_type' => 'incoming',
-                            ],
-                            [
-                                'content' => 'I\'ll review your billing details right away. Can you please provide your account ID?',
-                                'message_type' => 'outgoing',
-                                'sender' => 'angela@paperlayer.test',
-                            ],
+                'name' => 'Renie Champ',
+                'email' => 'rchamp4@stackoverflow.test',
+                'conversations' => [[
+                    'channel' => 'Sms',
+                    'source_id' => 'sms_005',
+                    'assignee' => 'ben@paperlayer.test',
+                    'priority' => 'medium',
+                    'labels' => ['delivery'],
+                    'messages' => [
+                        [
+                            'content' => 'Our delivery updates are delayed in dashboard.',
+                            'message_type' => 'incoming',
+                        ],
+                        [
+                            'content' => 'I checked and found the sync lag. We have started a fix and I will keep you posted.',
+                            'message_type' => 'outgoing',
+                            'sender' => 'ben@paperlayer.test',
                         ],
                     ],
-                ],
+                ]],
             ],
             [
-                'name' => 'Emma Thompson',
-                'email' => 'emma@consulting.com',
-                'conversations' => [
-                    [
-                        'channel' => 'Api',
-                        'source_id' => 'api_006',
-                        'assignee' => 'oscar@paperlayer.test',
-                        'priority' => 'medium',
-                        'labels' => ['Support'],
-                        'messages' => [
-                            [
-                                'content' => 'How do I authenticate API requests? The documentation is unclear.',
-                                'message_type' => 'incoming',
-                            ],
-                            [
-                                'content' => 'For API authentication, you need to include your API key in the Authorization header. I\'ll send you a detailed guide.',
-                                'message_type' => 'outgoing',
-                                'sender' => 'oscar@paperlayer.test',
-                            ],
+                'name' => 'Louise Farny',
+                'email' => 'lfarny5@developer.test',
+                'conversations' => [[
+                    'channel' => 'Email',
+                    'source_id' => 'email_006',
+                    'assignee' => 'cathy@paperlayer.test',
+                    'priority' => 'low',
+                    'labels' => ['software'],
+                    'messages' => [
+                        [
+                            'content' => 'Can you share best practices for knowledge base structure?',
+                            'message_type' => 'incoming',
+                        ],
+                        [
+                            'content' => 'Absolutely. I have shared a starter taxonomy and publishing workflow you can adopt.',
+                            'message_type' => 'outgoing',
+                            'sender' => 'cathy@paperlayer.test',
                         ],
                     ],
-                ],
+                ]],
             ],
             [
-                'name' => 'Alex Kim',
-                'email' => 'alex@ecommerce.shop',
-                'conversations' => [
-                    [
-                        'channel' => 'Telegram',
-                        'source_id' => 'tg_007',
-                        'assignee' => 'phyllis@paperlayer.test',
-                        'priority' => 'low',
-                        'labels' => ['Sales'],
-                        'messages' => [
-                            [
-                                'content' => 'Can I integrate this with my Shopify store?',
-                                'message_type' => 'incoming',
-                            ],
-                            [
-                                'content' => 'Yes! We have a Shopify integration available in our premium plans. Would you like to learn more?',
-                                'message_type' => 'outgoing',
-                                'sender' => 'phyllis@paperlayer.test',
-                            ],
+                'name' => 'Jaye Geldert',
+                'email' => 'jgeldert6@airbnb.test',
+                'conversations' => [[
+                    'channel' => 'Api',
+                    'source_id' => 'api_007',
+                    'assignee' => 'hunter@paperlayer.test',
+                    'priority' => 'medium',
+                    'labels' => ['lead'],
+                    'messages' => [
+                        [
+                            'content' => 'Which endpoint should I use for conversation assignment analytics?',
+                            'message_type' => 'incoming',
+                        ],
+                        [
+                            'content' => 'Use the reports endpoints for assignment analytics; I sent example query parameters.',
+                            'message_type' => 'outgoing',
+                            'sender' => 'hunter@paperlayer.test',
                         ],
                     ],
-                ],
+                ]],
             ],
             [
-                'name' => 'Rachel Green',
-                'email' => 'rachel@fashion.com',
-                'conversations' => [
-                    [
-                        'channel' => 'Line',
-                        'source_id' => 'line_008',
-                        'assignee' => 'kelly@paperlayer.test',
-                        'priority' => 'medium',
-                        'labels' => ['Support'],
-                        'messages' => [
-                            [
-                                'content' => 'The mobile app keeps crashing when I try to view reports.',
-                                'message_type' => 'incoming',
-                            ],
-                            [
-                                'content' => 'I\'m sorry to hear about the app crashes. Let me help you troubleshoot this issue.',
-                                'message_type' => 'outgoing',
-                                'sender' => 'kelly@paperlayer.test',
-                            ],
+                'name' => 'Inna McIlory',
+                'email' => 'imcilory7@spotify.test',
+                'conversations' => [[
+                    'channel' => 'Telegram',
+                    'source_id' => 'tg_008',
+                    'assignee' => 'lonny@paperlayer.test',
+                    'priority' => 'high',
+                    'labels' => ['premium-customer'],
+                    'messages' => [
+                        [
+                            'content' => 'We need white-glove migration support for premium workspace setup.',
+                            'message_type' => 'incoming',
+                        ],
+                        [
+                            'content' => 'Thank you for reaching out. I am coordinating your premium onboarding right now.',
+                            'message_type' => 'outgoing',
+                            'sender' => 'lonny@paperlayer.test',
                         ],
                     ],
-                ],
+                ]],
             ],
             [
-                'name' => 'Tom Anderson',
-                'email' => 'tom@logistics.com',
-                'conversations' => [
-                    [
-                        'channel' => 'Voice',
-                        'source_id' => 'voice_009',
-                        'assignee' => 'andy@paperlayer.test',
-                        'priority' => 'high',
-                        'labels' => ['Priority', 'Support'],
-                        'messages' => [
-                            [
-                                'content' => 'Voice call initiated - Customer needs urgent assistance with system outage.',
-                                'message_type' => 'incoming',
-                            ],
-                            [
-                                'content' => 'I\'m connecting you with our technical team right away. Please hold.',
-                                'message_type' => 'outgoing',
-                                'sender' => 'andy@paperlayer.test',
-                            ],
+                'name' => 'Micaela Fosey',
+                'email' => 'mfosey8@figma.test',
+                'conversations' => [[
+                    'channel' => 'Line',
+                    'source_id' => 'line_009',
+                    'assignee' => 'madge@paperlayer.test',
+                    'priority' => 'high',
+                    'labels' => ['delivery', 'ops-handover'],
+                    'messages' => [
+                        [
+                            'content' => 'Can you help us coordinate shipment handover in local timezone?',
+                            'message_type' => 'incoming',
+                        ],
+                        [
+                            'content' => 'Yes. I have added a step-by-step handover timeline and assigned an operations owner.',
+                            'message_type' => 'outgoing',
+                            'sender' => 'madge@paperlayer.test',
                         ],
                     ],
-                ],
+                ]],
             ],
         ];
     }

--- a/laravel-svelte-port/laravel/app/DataTransferObjects/SeedData.php
+++ b/laravel-svelte-port/laravel/app/DataTransferObjects/SeedData.php
@@ -142,7 +142,7 @@ class SeedData extends Data
             [
                 'name' => 'Karen Filippelli',
                 'gender' => 'female',
-                'email' => 'karn@paperlayer.test',
+                'email' => 'karen@paperlayer.test',
                 'teams' => ['Sales'],
                 'custom_role' => 'Sales Representative',
             ],
@@ -264,7 +264,7 @@ class SeedData extends Data
                 'conversations' => [[
                     'channel' => 'FacebookPage',
                     'source_id' => 'fb_002',
-                    'assignee' => 'karn@paperlayer.test',
+                    'assignee' => 'karen@paperlayer.test',
                     'priority' => 'high',
                     'labels' => ['billing', 'premium-customer'],
                     'messages' => [

--- a/laravel-svelte-port/laravel/app/Http/Controllers/Api/V2/LiveReportsController.php
+++ b/laravel-svelte-port/laravel/app/Http/Controllers/Api/V2/LiveReportsController.php
@@ -2,8 +2,8 @@
 
 namespace App\Http\Controllers\Api\V2;
 
-use App\Actions\Reports\GetLiveConversationMetricsAction;
 use App\Actions\Reports\GetGroupedConversationMetricsAction;
+use App\Actions\Reports\GetLiveConversationMetricsAction;
 use App\Http\Controllers\Api\V1\Concerns\RequiresAccountAdmin;
 use App\Http\Controllers\Controller;
 use App\Models\Account;
@@ -12,7 +12,7 @@ use Illuminate\Http\Request;
 
 /**
  * Live Reports Controller
- * 
+ *
  * Provides real-time conversation metrics for dashboards.
  * Rails parity: app/controllers/api/v2/accounts/live_reports_controller.rb
  */
@@ -22,45 +22,45 @@ class LiveReportsController extends Controller
 
     /**
      * Get live conversation metrics.
-     * 
+     *
      * GET /api/v2/accounts/{account}/live_reports/conversation_metrics
      */
     public function conversationMetrics(Request $request, Account $account): JsonResponse
     {
         $this->ensureAdmin($request, $account);
-        
+
         $metrics = GetLiveConversationMetricsAction::run(
             $account->id,
             $request->input('team_id')
         );
-        
-        return response()->json(['data' => $metrics]);
+
+        return response()->json($metrics);
     }
 
     /**
      * Get grouped conversation metrics.
-     * 
+     *
      * GET /api/v2/accounts/{account}/live_reports/grouped_conversation_metrics
      */
     public function groupedConversationMetrics(Request $request, Account $account): JsonResponse
     {
         $this->ensureAdmin($request, $account);
-        
+
         $groupBy = $request->input('group_by');
-        
+
         // Validate group_by parameter
-        if (!in_array($groupBy, ['team_id', 'assignee_id'])) {
+        if (! in_array($groupBy, ['team_id', 'assignee_id'])) {
             return response()->json(['error' => 'invalid group_by'], 422);
         }
-        
+
         try {
             $metrics = GetGroupedConversationMetricsAction::run(
                 $account->id,
                 $groupBy,
                 $request->input('team_id')
             );
-            
-            return response()->json(['data' => $metrics]);
+
+            return response()->json($metrics);
         } catch (\InvalidArgumentException $e) {
             return response()->json(['error' => $e->getMessage()], 422);
         }

--- a/laravel-svelte-port/laravel/app/Http/Controllers/Api/V2/ReportsController.php
+++ b/laravel-svelte-port/laravel/app/Http/Controllers/Api/V2/ReportsController.php
@@ -13,7 +13,6 @@ use App\Services\Reports\V2\Reports\Conversations\MetricBuilder;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
-use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Response as ResponseFacade;
 
 class ReportsController extends Controller
@@ -339,10 +338,33 @@ class ReportsController extends Controller
      */
     private function generateAgentsReport(Account $account, Request $request): array
     {
-        // This would use the AgentSummaryBuilder when implemented
+        $reports = (new \App\Services\Reports\V2\Reports\AgentSummaryBuilder(
+            $account,
+            $this->buildSummaryReportParams($request)
+        ))->build()['agents'] ?? [];
+
+        $reportById = collect($reports)->keyBy('id');
+
+        $rows = $account->users()
+            ->nonAdministrators()
+            ->get()
+            ->map(function ($agent) use ($reportById) {
+                $report = $reportById->get($agent->id, []);
+
+                return [
+                    $agent->name,
+                    $report['conversations_count'] ?? 0,
+                    $this->formatDuration($report['avg_first_response_time'] ?? null),
+                    $this->formatDuration($report['avg_resolution_time'] ?? null),
+                    $this->formatDuration($report['reply_time'] ?? null),
+                    $report['resolutions_count'] ?? 0,
+                ];
+            })
+            ->all();
+
         return [
-            'headers' => ['Agent Name', 'Email', 'Conversations', 'Resolved', 'Avg Response Time'],
-            'data' => [],
+            'headers' => ['Agent Name', 'Conversations', 'Avg First Response Time', 'Avg Resolution Time', 'Avg Reply Time', 'Resolution Count'],
+            'data' => $rows,
         ];
     }
 
@@ -351,10 +373,30 @@ class ReportsController extends Controller
      */
     private function generateInboxesReport(Account $account, Request $request): array
     {
-        // This would use the InboxSummaryBuilder when implemented
+        $reports = (new \App\Services\Reports\V2\Reports\InboxSummaryBuilder(
+            $account,
+            $this->buildSummaryReportParams($request)
+        ))->build()['inboxes'] ?? [];
+
+        $reportById = collect($reports)->keyBy('id');
+
+        $rows = $account->inboxes()->with('channel')->get()
+            ->map(function ($inbox) use ($reportById) {
+                $report = $reportById->get($inbox->id, []);
+
+                return [
+                    $inbox->name,
+                    $report['channel_name'] ?? class_basename((string) $inbox->channel_type),
+                    $report['conversations_count'] ?? 0,
+                    $this->formatDuration($report['avg_first_response_time'] ?? null),
+                    $this->formatDuration($report['avg_resolution_time'] ?? null),
+                ];
+            })
+            ->all();
+
         return [
-            'headers' => ['Inbox Name', 'Channel', 'Conversations', 'Resolved', 'Response Rate'],
-            'data' => [],
+            'headers' => ['Inbox Name', 'Inbox Type', 'Conversations', 'Avg First Response Time', 'Avg Resolution Time'],
+            'data' => $rows,
         ];
     }
 
@@ -363,10 +405,27 @@ class ReportsController extends Controller
      */
     private function generateLabelsReport(Account $account, Request $request): array
     {
-        // This would use the LabelSummaryBuilder when implemented
+        $reports = (new \App\Services\Reports\V2\Reports\LabelSummaryBuilder(
+            $account,
+            $this->buildSummaryReportParams($request)
+        ))->build()['labels'] ?? [];
+
+        $rows = collect($reports)
+            ->map(function (array $report) {
+                return [
+                    $report['title'] ?? '',
+                    $report['conversations_count'] ?? 0,
+                    $this->formatDuration($report['avg_first_response_time'] ?? null),
+                    $this->formatDuration($report['avg_resolution_time'] ?? null),
+                    $this->formatDuration($report['reply_time'] ?? null),
+                    $report['resolutions_count'] ?? 0,
+                ];
+            })
+            ->all();
+
         return [
-            'headers' => ['Label', 'Conversations', 'Usage %'],
-            'data' => [],
+            'headers' => ['Label', 'Conversations', 'Avg First Response Time', 'Avg Resolution Time', 'Avg Reply Time', 'Resolution Count'],
+            'data' => $rows,
         ];
     }
 
@@ -375,10 +434,31 @@ class ReportsController extends Controller
      */
     private function generateTeamsReport(Account $account, Request $request): array
     {
-        // This would use the TeamSummaryBuilder when implemented
+        $reports = (new \App\Services\Reports\V2\Reports\TeamSummaryBuilder(
+            $account,
+            $this->buildSummaryReportParams($request)
+        ))->build()['teams'] ?? [];
+
+        $reportById = collect($reports)->keyBy('id');
+
+        $rows = $account->teams()->get()
+            ->map(function ($team) use ($reportById) {
+                $report = $reportById->get($team->id, []);
+
+                return [
+                    $team->name,
+                    $report['conversations_count'] ?? 0,
+                    $this->formatDuration($report['avg_first_response_time'] ?? null),
+                    $this->formatDuration($report['avg_resolution_time'] ?? null),
+                    $this->formatDuration($report['reply_time'] ?? null),
+                    $report['resolutions_count'] ?? 0,
+                ];
+            })
+            ->all();
+
         return [
-            'headers' => ['Team Name', 'Members', 'Conversations', 'Resolved', 'Avg Response Time'],
-            'data' => [],
+            'headers' => ['Team Name', 'Conversations', 'Avg First Response Time', 'Avg Resolution Time', 'Avg Reply Time', 'Resolution Count'],
+            'data' => $rows,
         ];
     }
 
@@ -387,30 +467,52 @@ class ReportsController extends Controller
      */
     private function generateConversationsSummaryReport(Account $account, Request $request): array
     {
-        $since = $request->input('since', now()->subDays(30)->timestamp);
-        $until = $request->input('until', now()->timestamp);
-
-        $sinceAt = is_numeric($since) ? now()->createFromTimestamp((int) $since) : now()->parse($since);
-        $untilAt = is_numeric($until) ? now()->createFromTimestamp((int) $until) : now()->parse($until);
-
-        $summary = DB::table('conversations')
-            ->where('account_id', $account->id)
-            ->whereBetween('created_at', [$sinceAt, $untilAt])
-            ->selectRaw('COUNT(*) as conversations_count')
-            ->selectRaw('SUM(CASE WHEN status = ? THEN 1 ELSE 0 END) as open_count', [\App\Models\Conversation::STATUS_OPEN])
-            ->selectRaw('SUM(CASE WHEN status = ? THEN 1 ELSE 0 END) as resolved_count', [\App\Models\Conversation::STATUS_RESOLVED])
-            ->selectRaw('SUM(CASE WHEN status = ? THEN 1 ELSE 0 END) as pending_count', [\App\Models\Conversation::STATUS_PENDING])
-            ->first();
+        $params = $this->buildSummaryReportParams($request, ['type' => 'account']);
+        $summary = (new MetricBuilder($account, $params))->summary();
 
         return [
-            'headers' => ['conversations_count', 'open_count', 'resolved_count', 'pending_count'],
+            'headers' => ['conversations_count', 'incoming_messages_count', 'outgoing_messages_count', 'avg_first_response_time', 'avg_resolution_time', 'resolution_count', 'avg_reply_time'],
             'data' => [[
-                $summary->conversations_count ?? 0,
-                $summary->open_count ?? 0,
-                $summary->resolved_count ?? 0,
-                $summary->pending_count ?? 0,
+                $summary['conversations_count'] ?? 0,
+                $summary['incoming_messages_count'] ?? 0,
+                $summary['outgoing_messages_count'] ?? 0,
+                $this->formatDuration($summary['avg_first_response_time'] ?? null),
+                $this->formatDuration($summary['avg_resolution_time'] ?? null),
+                $summary['resolutions_count'] ?? 0,
+                $this->formatDuration($summary['reply_time'] ?? null),
             ]],
         ];
+    }
+
+    private function buildSummaryReportParams(Request $request, array $extra = []): array
+    {
+        return array_merge([
+            'since' => $request->input('since', now()->subDays(30)->timestamp),
+            'until' => $request->input('until', now()->timestamp),
+            'business_hours' => $request->boolean('business_hours', false),
+        ], $extra);
+    }
+
+    private function formatDuration(?float $seconds): string
+    {
+        if ($seconds === null) {
+            return '0s';
+        }
+
+        $total = (int) round($seconds);
+        $hours = intdiv($total, 3600);
+        $minutes = intdiv($total % 3600, 60);
+        $secs = $total % 60;
+
+        if ($hours > 0) {
+            return sprintf('%dh %dm %ds', $hours, $minutes, $secs);
+        }
+
+        if ($minutes > 0) {
+            return sprintf('%dm %ds', $minutes, $secs);
+        }
+
+        return sprintf('%ds', $secs);
     }
 
     /**

--- a/laravel-svelte-port/laravel/app/Http/Controllers/Api/V2/ReportsController.php
+++ b/laravel-svelte-port/laravel/app/Http/Controllers/Api/V2/ReportsController.php
@@ -53,7 +53,9 @@ class ReportsController extends Controller
             businessHours: $request->boolean('business_hours', false)
         );
 
-        return response()->json($data);
+        return response()->json([
+            'data' => $data,
+        ]);
     }
 
     /**

--- a/laravel-svelte-port/laravel/app/Http/Controllers/Api/V2/ReportsController.php
+++ b/laravel-svelte-port/laravel/app/Http/Controllers/Api/V2/ReportsController.php
@@ -2,17 +2,18 @@
 
 namespace App\Http\Controllers\Api\V2;
 
-use App\Actions\Reports\GetHeatmapDataAction;
 use App\Actions\Reports\ExportConversationTrafficAction;
+use App\Actions\Reports\GetHeatmapDataAction;
 use App\Http\Controllers\Api\V1\Concerns\RequiresAccountAdmin;
 use App\Http\Controllers\Controller;
 use App\Models\Account;
 use App\Services\Reports\V2\ReportBuilder;
-use App\Services\Reports\V2\Reports\Conversations\MetricBuilder;
 use App\Services\Reports\V2\Reports\BotMetricsBuilder;
+use App\Services\Reports\V2\Reports\Conversations\MetricBuilder;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Response as ResponseFacade;
 
 class ReportsController extends Controller
@@ -21,13 +22,13 @@ class ReportsController extends Controller
 
     /**
      * Get timeseries report data (for heatmaps).
-     * 
+     *
      * GET /api/v2/accounts/{account}/reports
      */
     public function index(Request $request, Account $account): JsonResponse
     {
         $this->ensureAdmin($request, $account);
-        
+
         // Validate parameters
         $request->validate([
             'metric' => 'required|string',
@@ -52,8 +53,8 @@ class ReportsController extends Controller
             id: $request->integer('id'),
             businessHours: $request->boolean('business_hours', false)
         );
-        
-        return response()->json(['data' => $data]);
+
+        return response()->json($data);
     }
 
     /**
@@ -62,9 +63,9 @@ class ReportsController extends Controller
     public function summary(Request $request, Account $account): JsonResponse
     {
         $this->ensureAdmin($request, $account);
-        
+
         $summary = $this->buildSummary($account, $request, 'summary');
-        
+
         return response()->json($summary);
     }
 
@@ -74,9 +75,9 @@ class ReportsController extends Controller
     public function botSummary(Request $request, Account $account): JsonResponse
     {
         $this->ensureAdmin($request, $account);
-        
+
         $summary = $this->buildSummary($account, $request, 'botSummary');
-        
+
         return response()->json($summary);
     }
 
@@ -86,9 +87,9 @@ class ReportsController extends Controller
     public function agents(Request $request, Account $account): Response
     {
         $this->ensureAdmin($request, $account);
-        
+
         $reportData = $this->generateAgentsReport($account, $request);
-        
+
         return $this->generateCsv('agents_report', $reportData);
     }
 
@@ -98,9 +99,9 @@ class ReportsController extends Controller
     public function inboxes(Request $request, Account $account): Response
     {
         $this->ensureAdmin($request, $account);
-        
+
         $reportData = $this->generateInboxesReport($account, $request);
-        
+
         return $this->generateCsv('inboxes_report', $reportData);
     }
 
@@ -110,9 +111,9 @@ class ReportsController extends Controller
     public function labels(Request $request, Account $account): Response
     {
         $this->ensureAdmin($request, $account);
-        
+
         $reportData = $this->generateLabelsReport($account, $request);
-        
+
         return $this->generateCsv('labels_report', $reportData);
     }
 
@@ -122,21 +123,33 @@ class ReportsController extends Controller
     public function teams(Request $request, Account $account): Response
     {
         $this->ensureAdmin($request, $account);
-        
+
         $reportData = $this->generateTeamsReport($account, $request);
-        
+
         return $this->generateCsv('teams_report', $reportData);
     }
 
     /**
+     * Get conversations summary report as CSV.
+     */
+    public function conversationsSummary(Request $request, Account $account): Response
+    {
+        $this->ensureAdmin($request, $account);
+
+        $reportData = $this->generateConversationsSummaryReport($account, $request);
+
+        return $this->generateCsv('conversations_summary_report', $reportData);
+    }
+
+    /**
      * Get conversation traffic report as CSV (heatmap export).
-     * 
+     *
      * GET /api/v2/accounts/{account}/reports/conversation_traffic
      */
     public function conversationTraffic(Request $request, Account $account): Response
     {
         $this->ensureAdmin($request, $account);
-        
+
         // Validate parameters
         $request->validate([
             'days_before' => 'nullable|integer|min:0|max:365',
@@ -149,10 +162,10 @@ class ReportsController extends Controller
             daysBefore: $request->integer('days_before', 6),
             timezoneOffset: $request->input('timezone_offset', 0)
         );
-        
+
         // Generate CSV
         $csv = $this->generateHeatmapCsv($result['data'], $result['timezone']);
-        
+
         return ResponseFacade::make($csv, 200, [
             'Content-Type' => 'text/csv',
             'Content-Disposition' => 'attachment; filename="conversation_traffic_reports.csv"',
@@ -187,15 +200,15 @@ class ReportsController extends Controller
     public function conversations(Request $request, Account $account): JsonResponse
     {
         $this->ensureAdmin($request, $account);
-        
+
         if (empty($request->get('type'))) {
             return response()->json(['error' => 'Type parameter is required'], 422);
         }
-        
+
         $params = $this->validateConversationParams($request);
         $builder = new ReportBuilder($account, $params);
         $metrics = $builder->conversationMetrics();
-        
+
         return response()->json($metrics);
     }
 
@@ -205,11 +218,11 @@ class ReportsController extends Controller
     public function botMetrics(Request $request, Account $account): JsonResponse
     {
         $this->ensureAdmin($request, $account);
-        
+
         $params = $this->validateReportParams($request);
         $builder = new BotMetricsBuilder($account, $params);
         $metrics = $builder->metrics();
-        
+
         return response()->json($metrics);
     }
 
@@ -265,25 +278,25 @@ class ReportsController extends Controller
     private function buildSummary(Account $account, Request $request, string $method): array
     {
         $range = $this->calculateDateRange($request);
-        
+
         $currentParams = $this->getCommonParams($request) + [
             'since' => $range['current']['since'],
             'until' => $range['current']['until'],
             'timezone_offset' => $request->get('timezone_offset', 0),
         ];
-        
+
         $previousParams = $this->getCommonParams($request) + [
             'since' => $range['previous']['since'],
             'until' => $range['previous']['until'],
             'timezone_offset' => $request->get('timezone_offset', 0),
         ];
-        
+
         $currentBuilder = new MetricBuilder($account, $currentParams);
         $previousBuilder = new MetricBuilder($account, $previousParams);
-        
+
         $currentSummary = $currentBuilder->$method();
         $previousSummary = $previousBuilder->$method();
-        
+
         return array_merge($currentSummary, ['previous' => $previousSummary]);
     }
 
@@ -308,7 +321,7 @@ class ReportsController extends Controller
         $since = strtotime($request->get('since'));
         $until = strtotime($request->get('until'));
         $duration = $until - $since;
-        
+
         return [
             'current' => [
                 'since' => $request->get('since'),
@@ -370,6 +383,37 @@ class ReportsController extends Controller
     }
 
     /**
+     * Generate conversations summary report data.
+     */
+    private function generateConversationsSummaryReport(Account $account, Request $request): array
+    {
+        $since = $request->input('since', now()->subDays(30)->timestamp);
+        $until = $request->input('until', now()->timestamp);
+
+        $sinceAt = is_numeric($since) ? now()->createFromTimestamp((int) $since) : now()->parse($since);
+        $untilAt = is_numeric($until) ? now()->createFromTimestamp((int) $until) : now()->parse($until);
+
+        $summary = DB::table('conversations')
+            ->where('account_id', $account->id)
+            ->whereBetween('created_at', [$sinceAt, $untilAt])
+            ->selectRaw('COUNT(*) as conversations_count')
+            ->selectRaw('SUM(CASE WHEN status = ? THEN 1 ELSE 0 END) as open_count', [\App\Models\Conversation::STATUS_OPEN])
+            ->selectRaw('SUM(CASE WHEN status = ? THEN 1 ELSE 0 END) as resolved_count', [\App\Models\Conversation::STATUS_RESOLVED])
+            ->selectRaw('SUM(CASE WHEN status = ? THEN 1 ELSE 0 END) as pending_count', [\App\Models\Conversation::STATUS_PENDING])
+            ->first();
+
+        return [
+            'headers' => ['conversations_count', 'open_count', 'resolved_count', 'pending_count'],
+            'data' => [[
+                $summary->conversations_count ?? 0,
+                $summary->open_count ?? 0,
+                $summary->resolved_count ?? 0,
+                $summary->pending_count ?? 0,
+            ]],
+        ];
+    }
+
+    /**
      * Generate conversation traffic report data.
      */
     private function generateConversationTrafficReport(Account $account, Request $request): array
@@ -387,7 +431,7 @@ class ReportsController extends Controller
     private function generateCsv(string $filename, array $reportData): Response
     {
         $csv = $this->arrayToCsv($reportData);
-        
+
         return ResponseFacade::make($csv, 200, [
             'Content-Type' => 'text/csv',
             'Content-Disposition' => "attachment; filename={$filename}.csv",
@@ -400,23 +444,23 @@ class ReportsController extends Controller
     private function arrayToCsv(array $data): string
     {
         $output = fopen('php://temp', 'r+');
-        
+
         // Add headers
         if (isset($data['headers'])) {
             fputcsv($output, $data['headers']);
         }
-        
+
         // Add data rows
         if (isset($data['data'])) {
             foreach ($data['data'] as $row) {
                 fputcsv($output, $row);
             }
         }
-        
+
         rewind($output);
         $csv = stream_get_contents($output);
         fclose($output);
-        
+
         return $csv;
     }
 }

--- a/laravel-svelte-port/laravel/app/Services/Reports/V2/Reports/Conversations/MetricBuilder.php
+++ b/laravel-svelte-port/laravel/app/Services/Reports/V2/Reports/Conversations/MetricBuilder.php
@@ -7,6 +7,7 @@ use App\Models\ReportingEvent;
 use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
 
 class MetricBuilder
 {
@@ -93,10 +94,12 @@ class MetricBuilder
         $since = Carbon::parse($this->params['since']);
         $until = Carbon::parse($this->params['until']);
 
-        $labelings = \App\Models\Labeling::query()
-            ->whereIn('label_id', $ids)
-            ->where('labelable_type', \App\Models\Conversation::class)
-            ->get(['label_id', 'labelable_id']);
+        $labelings = DB::table('labelings')
+            ->join('conversations', 'labelings.labelable_id', '=', 'conversations.id')
+            ->where('conversations.account_id', $this->account->id)
+            ->whereIn('labelings.label_id', $ids)
+            ->whereIn('labelings.labelable_type', [\App\Models\Conversation::class, 'Conversation'])
+            ->get(['labelings.label_id', 'labelings.labelable_id']);
 
         $conversationIds = $labelings
             ->pluck('labelable_id')
@@ -199,10 +202,12 @@ class MetricBuilder
             case 'label':
                 if ($id) {
                     $query->whereIn('conversation_id', function ($subquery) use ($id) {
-                        $subquery->select('labelable_id')
+                        $subquery->select('labelings.labelable_id')
                             ->from('labelings')
-                            ->where('label_id', $id)
-                            ->where('labelable_type', \App\Models\Conversation::class);
+                            ->join('conversations', 'labelings.labelable_id', '=', 'conversations.id')
+                            ->where('labelings.label_id', $id)
+                            ->where('conversations.account_id', $this->account->id)
+                            ->whereIn('labelings.labelable_type', [\App\Models\Conversation::class, 'Conversation']);
                     });
                 }
                 break;

--- a/laravel-svelte-port/laravel/app/Services/Reports/V2/Reports/Conversations/MetricBuilder.php
+++ b/laravel-svelte-port/laravel/app/Services/Reports/V2/Reports/Conversations/MetricBuilder.php
@@ -56,17 +56,34 @@ class MetricBuilder
             return $this->summaryByLabelIds($ids);
         }
 
+        $idColumn = match ($type) {
+            'agent' => 'user_id',
+            'inbox' => 'inbox_id',
+            'team' => 'team_id',
+            default => throw new \InvalidArgumentException("Batch summary for type '{$type}' is not supported."),
+        };
+
+        $since = Carbon::parse($this->params['since']);
+        $until = Carbon::parse($this->params['until']);
+
+        $normalizedIds = collect($ids)->map(fn ($id) => (int) $id)->values();
+
+        $allEvents = ReportingEvent::query()
+            ->where('account_id', $this->account->id)
+            ->whereBetween('created_at', [$since, $until])
+            ->whereIn($idColumn, $normalizedIds)
+            ->get();
+
+        $eventsById = $allEvents->groupBy($idColumn);
+
         $summaries = [];
 
-        foreach ($ids as $id) {
-            $events = $this->getEventsForTypeAndId($type, (int) $id);
-
-            $summaries[(int) $id] = $this->buildSummaryFromEvents($events);
+        foreach ($normalizedIds as $id) {
+            $summaries[$id] = $this->buildSummaryFromEvents($eventsById->get($id, collect()));
         }
 
         return $summaries;
     }
-
 
     /**
      * Generate summary metrics for label IDs without per-label reporting-event queries.
@@ -78,7 +95,7 @@ class MetricBuilder
 
         $labelings = \App\Models\Labeling::query()
             ->whereIn('label_id', $ids)
-            ->whereIn('labelable_type', [\App\Models\Conversation::class, 'Conversation'])
+            ->where('labelable_type', \App\Models\Conversation::class)
             ->get(['label_id', 'labelable_id']);
 
         $conversationIds = $labelings
@@ -159,22 +176,6 @@ class MetricBuilder
     }
 
     /**
-     * Get reporting events for a specific type/id pair.
-     */
-    private function getEventsForTypeAndId(string $type, int $id): Collection
-    {
-        $since = Carbon::parse($this->params['since']);
-        $until = Carbon::parse($this->params['until']);
-
-        $query = ReportingEvent::where('account_id', $this->account->id)
-            ->whereBetween('created_at', [$since, $until]);
-
-        $this->applyTypeFilter($query, $type, $id);
-
-        return $query->get();
-    }
-
-    /**
      * Apply type-specific filters to the query.
      */
     private function applyTypeFilter(Builder $query, string $type, ?int $id = null): void
@@ -201,7 +202,7 @@ class MetricBuilder
                         $subquery->select('labelable_id')
                             ->from('labelings')
                             ->where('label_id', $id)
-                            ->whereIn('labelable_type', [\App\Models\Conversation::class, 'Conversation']);
+                            ->where('labelable_type', \App\Models\Conversation::class);
                     });
                 }
                 break;

--- a/laravel-svelte-port/laravel/app/Services/Reports/V2/Reports/Conversations/MetricBuilder.php
+++ b/laravel-svelte-port/laravel/app/Services/Reports/V2/Reports/Conversations/MetricBuilder.php
@@ -9,6 +9,7 @@ use Carbon\Carbon;
 class MetricBuilder
 {
     protected Account $account;
+
     protected array $params;
 
     public function __construct(Account $account, array $params)
@@ -24,9 +25,9 @@ class MetricBuilder
     {
         $since = Carbon::parse($this->params['since']);
         $until = Carbon::parse($this->params['until']);
-        
+
         $events = $this->getReportingEvents($since, $until);
-        
+
         return [
             'conversations_count' => $this->getConversationsCount($events),
             'incoming_messages_count' => $this->getIncomingMessagesCount($events),
@@ -45,9 +46,9 @@ class MetricBuilder
     {
         $since = Carbon::parse($this->params['since']);
         $until = Carbon::parse($this->params['until']);
-        
+
         $events = $this->getReportingEvents($since, $until);
-        
+
         return [
             'bot_resolutions_count' => $this->getBotResolutionsCount($events),
             'bot_handoffs_count' => $this->getBotHandoffsCount($events),
@@ -63,12 +64,12 @@ class MetricBuilder
     {
         $query = ReportingEvent::where('account_id', $this->account->id)
             ->whereBetween('created_at', [$since, $until]);
-        
+
         // Apply type filter if specified
         if (isset($this->params['type']) && $this->params['type'] !== 'account') {
             $this->applyTypeFilter($query);
         }
-        
+
         return $query->get();
     }
 
@@ -79,7 +80,7 @@ class MetricBuilder
     {
         $type = $this->params['type'];
         $id = $this->params['id'] ?? null;
-        
+
         switch ($type) {
             case 'agent':
                 if ($id) {
@@ -97,7 +98,14 @@ class MetricBuilder
                 }
                 break;
             case 'label':
-                // This would need to be implemented based on how labels are tracked
+                if ($id) {
+                    $conversationIds = \Illuminate\Support\Facades\DB::table('labelings')
+                        ->where('label_id', $id)
+                        ->whereIn('labelable_type', [\App\Models\Conversation::class, 'Conversation'])
+                        ->pluck('labelable_id');
+
+                    $query->whereIn('conversation_id', $conversationIds);
+                }
                 break;
         }
     }
@@ -144,12 +152,13 @@ class MetricBuilder
     private function getAvgFirstResponseTime($events): ?float
     {
         $firstResponseEvents = $events->where('name', 'first_response');
-        
+
         if ($firstResponseEvents->isEmpty()) {
             return null;
         }
-        
+
         $totalTime = $firstResponseEvents->sum('value');
+
         return $totalTime / $firstResponseEvents->count();
     }
 
@@ -159,12 +168,13 @@ class MetricBuilder
     private function getAvgResolutionTime($events): ?float
     {
         $resolutionEvents = $events->where('name', 'conversation_resolved');
-        
+
         if ($resolutionEvents->isEmpty()) {
             return null;
         }
-        
+
         $totalTime = $resolutionEvents->sum('value');
+
         return $totalTime / $resolutionEvents->count();
     }
 
@@ -174,12 +184,13 @@ class MetricBuilder
     private function getAvgReplyTime($events): ?float
     {
         $replyTimeEvents = $events->where('name', 'reply_time');
-        
+
         if ($replyTimeEvents->isEmpty()) {
             return null;
         }
-        
+
         $totalTime = $replyTimeEvents->sum('value');
+
         return $totalTime / $replyTimeEvents->count();
     }
 
@@ -207,11 +218,11 @@ class MetricBuilder
         $botResolutions = $this->getBotResolutionsCount($events);
         $botHandoffs = $this->getBotHandoffsCount($events);
         $totalBotInteractions = $botResolutions + $botHandoffs;
-        
+
         if ($totalBotInteractions === 0) {
             return 0.0;
         }
-        
+
         return ($botResolutions / $totalBotInteractions) * 100;
     }
 
@@ -221,12 +232,13 @@ class MetricBuilder
     private function getAvgBotResolutionTime($events): ?float
     {
         $botResolutionEvents = $events->where('name', 'conversation_bot_resolved');
-        
+
         if ($botResolutionEvents->isEmpty()) {
             return null;
         }
-        
+
         $totalTime = $botResolutionEvents->sum('value');
+
         return $totalTime / $botResolutionEvents->count();
     }
 }

--- a/laravel-svelte-port/laravel/app/Services/Reports/V2/Reports/Conversations/MetricBuilder.php
+++ b/laravel-svelte-port/laravel/app/Services/Reports/V2/Reports/Conversations/MetricBuilder.php
@@ -5,6 +5,8 @@ namespace App\Services\Reports\V2\Reports\Conversations;
 use App\Models\Account;
 use App\Models\ReportingEvent;
 use Carbon\Carbon;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Collection;
 
 class MetricBuilder
 {
@@ -40,6 +42,88 @@ class MetricBuilder
     }
 
     /**
+     * Generate summary metrics for a list of IDs for the configured type.
+     */
+    public function summaryByIds(array $ids): array
+    {
+        $type = $this->params['type'] ?? null;
+
+        if (! $type || $type === 'account' || empty($ids)) {
+            return [];
+        }
+
+        if ($type === 'label') {
+            return $this->summaryByLabelIds($ids);
+        }
+
+        $summaries = [];
+
+        foreach ($ids as $id) {
+            $events = $this->getEventsForTypeAndId($type, (int) $id);
+
+            $summaries[(int) $id] = $this->buildSummaryFromEvents($events);
+        }
+
+        return $summaries;
+    }
+
+    /**
+     * Generate summary metrics for label IDs without per-label reporting-event queries.
+     */
+    private function summaryByLabelIds(array $ids): array
+    {
+        $since = Carbon::parse($this->params['since']);
+        $until = Carbon::parse($this->params['until']);
+
+        $labelings = \App\Models\Labeling::query()
+            ->whereIn('label_id', $ids)
+            ->whereIn('labelable_type', [\App\Models\Conversation::class, 'Conversation'])
+            ->get(['label_id', 'labelable_id']);
+
+        $conversationIds = $labelings
+            ->pluck('labelable_id')
+            ->unique()
+            ->values()
+            ->all();
+
+        $events = ReportingEvent::query()
+            ->where('account_id', $this->account->id)
+            ->whereBetween('created_at', [$since, $until])
+            ->whereIn('conversation_id', $conversationIds)
+            ->get();
+
+        $conversationIdsByLabel = $labelings
+            ->groupBy('label_id')
+            ->map(fn (Collection $items) => $items->pluck('labelable_id')->unique()->all());
+
+        $summaries = [];
+
+        foreach ($ids as $id) {
+            $labelConversationIds = $conversationIdsByLabel->get((int) $id, []);
+            $labelEvents = $events->whereIn('conversation_id', $labelConversationIds);
+            $summaries[(int) $id] = $this->buildSummaryFromEvents($labelEvents);
+        }
+
+        return $summaries;
+    }
+
+    /**
+     * Build summary payload from reporting events.
+     */
+    private function buildSummaryFromEvents(Collection $events): array
+    {
+        return [
+            'conversations_count' => $this->getConversationsCount($events),
+            'incoming_messages_count' => $this->getIncomingMessagesCount($events),
+            'outgoing_messages_count' => $this->getOutgoingMessagesCount($events),
+            'resolutions_count' => $this->getResolutionsCount($events),
+            'avg_first_response_time' => $this->getAvgFirstResponseTime($events),
+            'avg_resolution_time' => $this->getAvgResolutionTime($events),
+            'reply_time' => $this->getAvgReplyTime($events),
+        ];
+    }
+
+    /**
      * Generate bot summary metrics.
      */
     public function botSummary(): array
@@ -60,15 +144,31 @@ class MetricBuilder
     /**
      * Get reporting events for the specified period.
      */
-    private function getReportingEvents(Carbon $since, Carbon $until)
+    private function getReportingEvents(Carbon $since, Carbon $until): Collection
     {
         $query = ReportingEvent::where('account_id', $this->account->id)
             ->whereBetween('created_at', [$since, $until]);
 
         // Apply type filter if specified
         if (isset($this->params['type']) && $this->params['type'] !== 'account') {
-            $this->applyTypeFilter($query);
+            $this->applyTypeFilter($query, $this->params['type'], $this->params['id'] ?? null);
         }
+
+        return $query->get();
+    }
+
+    /**
+     * Get reporting events for a specific type/id pair.
+     */
+    private function getEventsForTypeAndId(string $type, int $id): Collection
+    {
+        $since = Carbon::parse($this->params['since']);
+        $until = Carbon::parse($this->params['until']);
+
+        $query = ReportingEvent::where('account_id', $this->account->id)
+            ->whereBetween('created_at', [$since, $until]);
+
+        $this->applyTypeFilter($query, $type, $id);
 
         return $query->get();
     }
@@ -76,11 +176,8 @@ class MetricBuilder
     /**
      * Apply type-specific filters to the query.
      */
-    private function applyTypeFilter($query): void
+    private function applyTypeFilter(Builder $query, string $type, ?int $id = null): void
     {
-        $type = $this->params['type'];
-        $id = $this->params['id'] ?? null;
-
         switch ($type) {
             case 'agent':
                 if ($id) {
@@ -99,12 +196,12 @@ class MetricBuilder
                 break;
             case 'label':
                 if ($id) {
-                    $conversationIds = \Illuminate\Support\Facades\DB::table('labelings')
-                        ->where('label_id', $id)
-                        ->whereIn('labelable_type', [\App\Models\Conversation::class, 'Conversation'])
-                        ->pluck('labelable_id');
-
-                    $query->whereIn('conversation_id', $conversationIds);
+                    $query->whereIn('conversation_id', function ($subquery) use ($id) {
+                        $subquery->select('labelable_id')
+                            ->from('labelings')
+                            ->where('label_id', $id)
+                            ->whereIn('labelable_type', [\App\Models\Conversation::class, 'Conversation']);
+                    });
                 }
                 break;
         }

--- a/laravel-svelte-port/laravel/app/Services/Reports/V2/Reports/Conversations/MetricBuilder.php
+++ b/laravel-svelte-port/laravel/app/Services/Reports/V2/Reports/Conversations/MetricBuilder.php
@@ -5,6 +5,8 @@ namespace App\Services\Reports\V2\Reports\Conversations;
 use App\Models\Account;
 use App\Models\ReportingEvent;
 use Carbon\Carbon;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Collection;
 
 class MetricBuilder
 {
@@ -40,6 +42,89 @@ class MetricBuilder
     }
 
     /**
+     * Generate summary metrics for a list of IDs for the configured type.
+     */
+    public function summaryByIds(array $ids): array
+    {
+        $type = $this->params['type'] ?? null;
+
+        if (! $type || $type === 'account' || empty($ids)) {
+            return [];
+        }
+
+        if ($type === 'label') {
+            return $this->summaryByLabelIds($ids);
+        }
+
+        $summaries = [];
+
+        foreach ($ids as $id) {
+            $events = $this->getEventsForTypeAndId($type, (int) $id);
+
+            $summaries[(int) $id] = $this->buildSummaryFromEvents($events);
+        }
+
+        return $summaries;
+    }
+
+
+    /**
+     * Generate summary metrics for label IDs without per-label reporting-event queries.
+     */
+    private function summaryByLabelIds(array $ids): array
+    {
+        $since = Carbon::parse($this->params['since']);
+        $until = Carbon::parse($this->params['until']);
+
+        $labelings = \App\Models\Labeling::query()
+            ->whereIn('label_id', $ids)
+            ->whereIn('labelable_type', [\App\Models\Conversation::class, 'Conversation'])
+            ->get(['label_id', 'labelable_id']);
+
+        $conversationIds = $labelings
+            ->pluck('labelable_id')
+            ->unique()
+            ->values()
+            ->all();
+
+        $events = ReportingEvent::query()
+            ->where('account_id', $this->account->id)
+            ->whereBetween('created_at', [$since, $until])
+            ->whereIn('conversation_id', $conversationIds)
+            ->get();
+
+        $conversationIdsByLabel = $labelings
+            ->groupBy('label_id')
+            ->map(fn (Collection $items) => $items->pluck('labelable_id')->unique()->all());
+
+        $summaries = [];
+
+        foreach ($ids as $id) {
+            $labelConversationIds = $conversationIdsByLabel->get((int) $id, []);
+            $labelEvents = $events->whereIn('conversation_id', $labelConversationIds);
+            $summaries[(int) $id] = $this->buildSummaryFromEvents($labelEvents);
+        }
+
+        return $summaries;
+    }
+
+    /**
+     * Build summary payload from reporting events.
+     */
+    private function buildSummaryFromEvents(Collection $events): array
+    {
+        return [
+            'conversations_count' => $this->getConversationsCount($events),
+            'incoming_messages_count' => $this->getIncomingMessagesCount($events),
+            'outgoing_messages_count' => $this->getOutgoingMessagesCount($events),
+            'resolutions_count' => $this->getResolutionsCount($events),
+            'avg_first_response_time' => $this->getAvgFirstResponseTime($events),
+            'avg_resolution_time' => $this->getAvgResolutionTime($events),
+            'reply_time' => $this->getAvgReplyTime($events),
+        ];
+    }
+
+    /**
      * Generate bot summary metrics.
      */
     public function botSummary(): array
@@ -60,15 +145,31 @@ class MetricBuilder
     /**
      * Get reporting events for the specified period.
      */
-    private function getReportingEvents(Carbon $since, Carbon $until)
+    private function getReportingEvents(Carbon $since, Carbon $until): Collection
     {
         $query = ReportingEvent::where('account_id', $this->account->id)
             ->whereBetween('created_at', [$since, $until]);
 
         // Apply type filter if specified
         if (isset($this->params['type']) && $this->params['type'] !== 'account') {
-            $this->applyTypeFilter($query);
+            $this->applyTypeFilter($query, $this->params['type'], $this->params['id'] ?? null);
         }
+
+        return $query->get();
+    }
+
+    /**
+     * Get reporting events for a specific type/id pair.
+     */
+    private function getEventsForTypeAndId(string $type, int $id): Collection
+    {
+        $since = Carbon::parse($this->params['since']);
+        $until = Carbon::parse($this->params['until']);
+
+        $query = ReportingEvent::where('account_id', $this->account->id)
+            ->whereBetween('created_at', [$since, $until]);
+
+        $this->applyTypeFilter($query, $type, $id);
 
         return $query->get();
     }
@@ -76,11 +177,8 @@ class MetricBuilder
     /**
      * Apply type-specific filters to the query.
      */
-    private function applyTypeFilter($query): void
+    private function applyTypeFilter(Builder $query, string $type, ?int $id = null): void
     {
-        $type = $this->params['type'];
-        $id = $this->params['id'] ?? null;
-
         switch ($type) {
             case 'agent':
                 if ($id) {
@@ -99,12 +197,12 @@ class MetricBuilder
                 break;
             case 'label':
                 if ($id) {
-                    $conversationIds = \Illuminate\Support\Facades\DB::table('labelings')
-                        ->where('label_id', $id)
-                        ->whereIn('labelable_type', [\App\Models\Conversation::class, 'Conversation'])
-                        ->pluck('labelable_id');
-
-                    $query->whereIn('conversation_id', $conversationIds);
+                    $query->whereIn('conversation_id', function ($subquery) use ($id) {
+                        $subquery->select('labelable_id')
+                            ->from('labelings')
+                            ->where('label_id', $id)
+                            ->whereIn('labelable_type', [\App\Models\Conversation::class, 'Conversation']);
+                    });
                 }
                 break;
         }

--- a/laravel-svelte-port/laravel/app/Services/Reports/V2/Reports/LabelSummaryBuilder.php
+++ b/laravel-svelte-port/laravel/app/Services/Reports/V2/Reports/LabelSummaryBuilder.php
@@ -2,8 +2,6 @@
 
 namespace App\Services\Reports\V2\Reports;
 
-use Illuminate\Support\Facades\DB;
-
 class LabelSummaryBuilder extends BaseSummaryBuilder
 {
     /**
@@ -12,33 +10,45 @@ class LabelSummaryBuilder extends BaseSummaryBuilder
     public function build(): array
     {
         $dateRange = $this->getDateRange();
-        
-        // Get all labels for this account
+
         $labels = $this->account->labels()->get();
-        
-        $labelSummaries = [];
         $totalConversations = $this->getTotalConversationsInPeriod($dateRange);
-        
+
+        $labelSummaries = [];
+
         foreach ($labels as $label) {
-            $labelUsage = $this->getLabelUsage($label, $dateRange);
-            $usagePercentage = $totalConversations > 0 ? 
-                ($labelUsage / $totalConversations) * 100 : 0;
-            
+            $summary = (new \App\Services\Reports\V2\Reports\Conversations\MetricBuilder($this->account, [
+                'since' => $dateRange['since'],
+                'until' => $dateRange['until'],
+                'type' => 'label',
+                'id' => $label->id,
+                'business_hours' => $this->shouldUseBusinessHours(),
+            ]))->summary();
+
+            $usagePercentage = $totalConversations > 0
+                ? (($summary['conversations_count'] ?? 0) / $totalConversations) * 100
+                : 0;
+
             $labelSummaries[] = [
                 'id' => $label->id,
                 'title' => $label->title,
                 'description' => $label->description,
                 'color' => $label->color,
-                'conversations_count' => $labelUsage,
+                'conversations_count' => $summary['conversations_count'] ?? 0,
+                'incoming_messages_count' => $summary['incoming_messages_count'] ?? 0,
+                'outgoing_messages_count' => $summary['outgoing_messages_count'] ?? 0,
+                'resolutions_count' => $summary['resolutions_count'] ?? 0,
+                'avg_first_response_time' => $summary['avg_first_response_time'] ?? null,
+                'avg_resolution_time' => $summary['avg_resolution_time'] ?? null,
+                'reply_time' => $summary['reply_time'] ?? null,
                 'usage_percentage' => round($usagePercentage, 2),
             ];
         }
-        
-        // Sort by usage count descending
+
         usort($labelSummaries, function ($a, $b) {
             return $b['conversations_count'] <=> $a['conversations_count'];
         });
-        
+
         return [
             'labels' => $labelSummaries,
             'period' => [
@@ -57,21 +67,6 @@ class LabelSummaryBuilder extends BaseSummaryBuilder
     {
         return $this->account->conversations()
             ->whereBetween('created_at', [$dateRange['since'], $dateRange['until']])
-            ->count();
-    }
-
-    /**
-     * Get label usage count in the period.
-     */
-    private function getLabelUsage($label, array $dateRange): int
-    {
-        // This assumes there's a conversation_labels pivot table
-        // The exact implementation would depend on how labels are associated with conversations
-        return DB::table('conversation_labels')
-            ->join('conversations', 'conversation_labels.conversation_id', '=', 'conversations.id')
-            ->where('conversation_labels.label_id', $label->id)
-            ->where('conversations.account_id', $this->account->id)
-            ->whereBetween('conversations.created_at', [$dateRange['since'], $dateRange['until']])
             ->count();
     }
 }

--- a/laravel-svelte-port/laravel/app/Services/Reports/V2/Reports/LabelSummaryBuilder.php
+++ b/laravel-svelte-port/laravel/app/Services/Reports/V2/Reports/LabelSummaryBuilder.php
@@ -16,14 +16,14 @@ class LabelSummaryBuilder extends BaseSummaryBuilder
 
         $labelSummaries = [];
 
+        $summaryByLabelId = (new \App\Services\Reports\V2\Reports\Conversations\MetricBuilder($this->account, [
+            'since' => $dateRange['since'],
+            'until' => $dateRange['until'],
+            'type' => 'label',
+        ]))->summaryByIds($labels->pluck('id')->all());
+
         foreach ($labels as $label) {
-            $summary = (new \App\Services\Reports\V2\Reports\Conversations\MetricBuilder($this->account, [
-                'since' => $dateRange['since'],
-                'until' => $dateRange['until'],
-                'type' => 'label',
-                'id' => $label->id,
-                'business_hours' => $this->shouldUseBusinessHours(),
-            ]))->summary();
+            $summary = $summaryByLabelId[$label->id] ?? [];
 
             $usagePercentage = $totalConversations > 0
                 ? (($summary['conversations_count'] ?? 0) / $totalConversations) * 100

--- a/laravel-svelte-port/laravel/app/Services/Seeding/AccountSeederService.php
+++ b/laravel-svelte-port/laravel/app/Services/Seeding/AccountSeederService.php
@@ -5,34 +5,37 @@ namespace App\Services\Seeding;
 use App\DataTransferObjects\SeedData;
 use App\Enums\AccountUserRole;
 use App\Models\Account;
-use App\Models\User;
-use App\Models\Team;
-use App\Models\CustomRole;
-use App\Models\Label;
-use App\Models\Contact;
-use App\Models\Inbox;
-use App\Models\Conversation;
-use App\Models\Message;
-use App\Models\CannedResponse;
 use App\Models\AccountUser;
-use App\Models\ContactInbox;
-use App\Models\Channels\WebWidget;
-use App\Models\Channels\FacebookPage;
-use App\Models\Channels\TwitterProfile;
-use App\Models\Channels\Whatsapp;
-use App\Models\Channels\Sms;
-use App\Models\Channels\Email;
+use App\Models\CannedResponse;
 use App\Models\Channels\Api;
-use App\Models\Channels\Telegram;
+use App\Models\Channels\Email;
+use App\Models\Channels\FacebookPage;
 use App\Models\Channels\Line;
+use App\Models\Channels\Sms;
+use App\Models\Channels\Telegram;
+use App\Models\Channels\TwitterProfile;
 use App\Models\Channels\Voice;
+use App\Models\Channels\WebWidget;
+use App\Models\Channels\Whatsapp;
+use App\Models\Contact;
+use App\Models\ContactInbox;
+use App\Models\Conversation;
+use App\Models\CustomRole;
+use App\Models\Inbox;
+use App\Models\Label;
+use App\Models\Message;
+use App\Models\Team;
+use App\Models\User;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Str;
 
 class AccountSeederService
 {
     private Account $account;
+
     private SeedData $seedData;
+
+    private array $teamLookup = [];
 
     public function __construct(Account $account, ?SeedData $seedData = null)
     {
@@ -59,7 +62,7 @@ class AccountSeederService
         ];
 
         $this->cleanupExistingData();
-        
+
         $stats['teams_created'] = $this->seedTeams();
         $stats['custom_roles_created'] = $this->seedCustomRoles();
         $stats['users_created'] = $this->seedUsers();
@@ -76,18 +79,18 @@ class AccountSeederService
      */
     private function cleanupExistingData(): void
     {
-        // Use raw database queries to avoid model issues
+        // Use raw database queries to avoid model relationship side-effects.
+        // Order matters to preserve referential integrity.
         \Illuminate\Support\Facades\DB::table('team_members')
-            ->whereIn('team_id', function($query) {
+            ->whereIn('team_id', function ($query) {
                 $query->select('id')->from('teams')->where('account_id', $this->account->id);
             })->delete();
-        
+
         // Delete account_users relationships first
         \Illuminate\Support\Facades\DB::table('account_users')->where('account_id', $this->account->id)->delete();
-        
-        // Delete test users (users with @paperlayer.test emails)
-        \Illuminate\Support\Facades\DB::table('users')->where('email', 'like', '%@paperlayer.test')->delete();
-        
+
+        // Delete seeded test users only when they no longer belong to any account.
+
         // Delete all channel tables for this account
         \Illuminate\Support\Facades\DB::table('channel_web_widgets')->where('account_id', $this->account->id)->delete();
         \Illuminate\Support\Facades\DB::table('channel_facebook_pages')->where('account_id', $this->account->id)->delete();
@@ -99,17 +102,26 @@ class AccountSeederService
         \Illuminate\Support\Facades\DB::table('channel_telegram')->where('account_id', $this->account->id)->delete();
         \Illuminate\Support\Facades\DB::table('channel_line')->where('account_id', $this->account->id)->delete();
         \Illuminate\Support\Facades\DB::table('channel_voice')->where('account_id', $this->account->id)->delete();
-        
+
         \Illuminate\Support\Facades\DB::table('teams')->where('account_id', $this->account->id)->delete();
         \Illuminate\Support\Facades\DB::table('conversations')->where('account_id', $this->account->id)->delete();
-        \Illuminate\Support\Facades\DB::table('labels')->where('account_id', $this->account->id)->delete();
-        \Illuminate\Support\Facades\DB::table('labelings')->whereIn('label_id', function($query) {
+        \Illuminate\Support\Facades\DB::table('labelings')->whereIn('label_id', function ($query) {
             $query->select('id')->from('labels')->where('account_id', $this->account->id);
         })->delete();
+        \Illuminate\Support\Facades\DB::table('labels')->where('account_id', $this->account->id)->delete();
         \Illuminate\Support\Facades\DB::table('inboxes')->where('account_id', $this->account->id)->delete();
         \Illuminate\Support\Facades\DB::table('contacts')->where('account_id', $this->account->id)->delete();
         \Illuminate\Support\Facades\DB::table('custom_roles')->where('account_id', $this->account->id)->delete();
         \Illuminate\Support\Facades\DB::table('canned_responses')->where('account_id', $this->account->id)->delete();
+
+        \Illuminate\Support\Facades\DB::table('users')
+            ->where('email', 'like', '%@paperlayer.test')
+            ->whereNotExists(function ($query) {
+                $query->selectRaw('1')
+                    ->from('account_users')
+                    ->whereColumn('account_users.user_id', 'users.id');
+            })
+            ->delete();
     }
 
     /**
@@ -119,12 +131,15 @@ class AccountSeederService
     {
         $count = 0;
         foreach ($this->seedData->teams as $teamName) {
-            Team::factory()->create([
+            $team = Team::factory()->create([
                 'account_id' => $this->account->id,
                 'name' => $teamName,
             ]);
+
+            $this->teamLookup[$this->normalizeTeamName($teamName)] = $team;
             $count++;
         }
+
         return $count;
     }
 
@@ -143,6 +158,7 @@ class AccountSeederService
             ]);
             $count++;
         }
+
         return $count;
     }
 
@@ -161,13 +177,14 @@ class AccountSeederService
             ]);
 
             $this->createAccountUser($user, $userData);
-            
-            if (!empty($userData['teams'])) {
+
+            if (! empty($userData['teams'])) {
                 $this->addUserToTeams($user, $userData['teams']);
             }
-            
+
             $count++;
         }
+
         return $count;
     }
 
@@ -186,6 +203,7 @@ class AccountSeederService
             ]);
             $count++;
         }
+
         return $count;
     }
 
@@ -199,51 +217,51 @@ class AccountSeederService
 
         // Create all channel types using factories
         $channels = [
-            'WebWidget' => fn() => WebWidget::factory()->create([
+            'WebWidget' => fn () => WebWidget::factory()->create([
                 'account_id' => $this->account->id,
                 'website_url' => "https://{$companyData->domain}",
             ]),
-            'FacebookPage' => fn() => FacebookPage::factory()->create([
+            'FacebookPage' => fn () => FacebookPage::factory()->create([
                 'account_id' => $this->account->id,
             ]),
-            'TwitterProfile' => fn() => TwitterProfile::factory()->create([
+            'TwitterProfile' => fn () => TwitterProfile::factory()->create([
                 'account_id' => $this->account->id,
             ]),
-            'Whatsapp' => fn() => Whatsapp::factory()->create([
+            'Whatsapp' => fn () => Whatsapp::factory()->create([
                 'account_id' => $this->account->id,
             ]),
-            'Sms' => fn() => Sms::factory()->create([
+            'Sms' => fn () => Sms::factory()->create([
                 'account_id' => $this->account->id,
             ]),
-            'Email' => fn() => Email::factory()->create([
+            'Email' => fn () => Email::factory()->create([
                 'account_id' => $this->account->id,
                 'email' => "support-{$this->account->id}@{$companyData->domain}",
             ]),
-            'Api' => fn() => Api::factory()->create([
+            'Api' => fn () => Api::factory()->create([
                 'account_id' => $this->account->id,
             ]),
-            'Telegram' => fn() => Telegram::factory()->create([
+            'Telegram' => fn () => Telegram::factory()->create([
                 'account_id' => $this->account->id,
                 'bot_name' => $companyData->name,
             ]),
-            'Line' => fn() => Line::factory()->create([
+            'Line' => fn () => Line::factory()->create([
                 'account_id' => $this->account->id,
             ]),
-            'Voice' => fn() => Voice::factory()->demo()->create([
+            'Voice' => fn () => Voice::factory()->demo()->create([
                 'account_id' => $this->account->id,
             ]),
         ];
 
         foreach ($channels as $channelType => $channelFactory) {
             $channel = $channelFactory();
-            
+
             Inbox::factory()->create([
                 'account_id' => $this->account->id,
                 'name' => "{$companyData->name} {$channelType}",
                 'channel_type' => $channel::class,
                 'channel_id' => $channel->id,
             ]);
-            
+
             $count++;
         }
 
@@ -266,9 +284,10 @@ class AccountSeederService
             foreach ($contactData['conversations'] as $conversationData) {
                 $this->createConversation($contact, $conversationData);
             }
-            
+
             $count++;
         }
+
         return $count;
     }
 
@@ -280,7 +299,7 @@ class AccountSeederService
         $responses = CannedResponse::factory()
             ->count($count)
             ->create(['account_id' => $this->account->id]);
-            
+
         return $responses->count();
     }
 
@@ -291,16 +310,16 @@ class AccountSeederService
     {
         $roleName = $userData['role'] ?? 'agent';
         $role = AccountUserRole::fromName($roleName);
-        
+
         $accountUserData = [
             'role' => $role,
         ];
 
-        if (!empty($userData['custom_role'])) {
+        if (! empty($userData['custom_role'])) {
             $customRole = $this->account->customRoles()
                 ->where('name', $userData['custom_role'])
                 ->first();
-            
+
             if ($customRole) {
                 $accountUserData['custom_role_id'] = $customRole->id;
             }
@@ -319,9 +338,7 @@ class AccountSeederService
     private function addUserToTeams(User $user, array $teams): void
     {
         foreach ($teams as $teamName) {
-            $team = $this->account->teams()
-                ->where('name', 'LIKE', "%{$teamName}%")
-                ->first();
+            $team = $this->teamLookup[$this->normalizeTeamName($teamName)] ?? null;
 
             if ($team) {
                 $team->members()->syncWithoutDetaching([$user->id]);
@@ -335,8 +352,8 @@ class AccountSeederService
     private function createConversation(Contact $contact, array $conversationData): void
     {
         $inbox = $this->findInboxByChannel($conversationData['channel']);
-        
-        if (!$inbox) {
+
+        if (! $inbox) {
             return;
         }
 
@@ -347,7 +364,7 @@ class AccountSeederService
         ]);
 
         $assignee = null;
-        if (!empty($conversationData['assignee'])) {
+        if (! empty($conversationData['assignee'])) {
             $assignee = User::where('email', $conversationData['assignee'])->first();
         }
 
@@ -363,7 +380,7 @@ class AccountSeederService
 
         $this->createMessages($conversation, $conversationData['messages']);
 
-        if (!empty($conversationData['labels'])) {
+        if (! empty($conversationData['labels'])) {
             $this->attachLabels($conversation, $conversationData['labels']);
         }
     }
@@ -387,7 +404,7 @@ class AccountSeederService
         ];
 
         $channelClass = $channelClassMap[$channelType] ?? null;
-        if (!$channelClass) {
+        if (! $channelClass) {
             return null;
         }
 
@@ -425,7 +442,7 @@ class AccountSeederService
             return $conversation->contact;
         }
 
-        if (!empty($messageData['sender'])) {
+        if (! empty($messageData['sender'])) {
             return User::where('email', $messageData['sender'])->first();
         }
 
@@ -456,10 +473,10 @@ class AccountSeederService
             'total_labels' => count($this->seedData->labels),
             'total_contacts' => count($this->seedData->contacts),
             'total_conversations' => collect($this->seedData->contacts)
-                ->sum(fn($contact) => count($contact['conversations'])),
+                ->sum(fn ($contact) => count($contact['conversations'])),
             'total_messages' => collect($this->seedData->contacts)
-                ->flatMap(fn($contact) => $contact['conversations'])
-                ->sum(fn($conv) => count($conv['messages'])),
+                ->flatMap(fn ($contact) => $contact['conversations'])
+                ->sum(fn ($conv) => count($conv['messages'])),
         ];
     }
 
@@ -493,5 +510,12 @@ class AccountSeederService
             'template' => Message::TYPE_TEMPLATE,
             default => Message::TYPE_INCOMING,
         };
+    }
+
+    private function normalizeTeamName(string $teamName): string
+    {
+        $normalized = preg_replace('/[^\p{L}\p{N}\s]+/u', '', $teamName);
+
+        return strtolower(trim((string) $normalized));
     }
 }

--- a/laravel-svelte-port/laravel/app/Services/Seeding/AccountSeederService.php
+++ b/laravel-svelte-port/laravel/app/Services/Seeding/AccountSeederService.php
@@ -26,6 +26,7 @@ use App\Models\Label;
 use App\Models\Message;
 use App\Models\Team;
 use App\Models\User;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Str;
 
@@ -81,40 +82,40 @@ class AccountSeederService
     {
         // Use raw database queries to avoid model relationship side-effects.
         // Order matters to preserve referential integrity.
-        \Illuminate\Support\Facades\DB::table('team_members')
+        DB::table('team_members')
             ->whereIn('team_id', function ($query) {
                 $query->select('id')->from('teams')->where('account_id', $this->account->id);
             })->delete();
 
         // Delete account_users relationships first
-        \Illuminate\Support\Facades\DB::table('account_users')->where('account_id', $this->account->id)->delete();
+        DB::table('account_users')->where('account_id', $this->account->id)->delete();
 
         // Delete seeded test users only when they no longer belong to any account.
 
         // Delete all channel tables for this account
-        \Illuminate\Support\Facades\DB::table('channel_web_widgets')->where('account_id', $this->account->id)->delete();
-        \Illuminate\Support\Facades\DB::table('channel_facebook_pages')->where('account_id', $this->account->id)->delete();
-        \Illuminate\Support\Facades\DB::table('channel_twitter_profiles')->where('account_id', $this->account->id)->delete();
-        \Illuminate\Support\Facades\DB::table('channel_whatsapp')->where('account_id', $this->account->id)->delete();
-        \Illuminate\Support\Facades\DB::table('channel_sms')->where('account_id', $this->account->id)->delete();
-        \Illuminate\Support\Facades\DB::table('channel_email')->where('account_id', $this->account->id)->delete();
-        \Illuminate\Support\Facades\DB::table('channel_api')->where('account_id', $this->account->id)->delete();
-        \Illuminate\Support\Facades\DB::table('channel_telegram')->where('account_id', $this->account->id)->delete();
-        \Illuminate\Support\Facades\DB::table('channel_line')->where('account_id', $this->account->id)->delete();
-        \Illuminate\Support\Facades\DB::table('channel_voice')->where('account_id', $this->account->id)->delete();
+        DB::table('channel_web_widgets')->where('account_id', $this->account->id)->delete();
+        DB::table('channel_facebook_pages')->where('account_id', $this->account->id)->delete();
+        DB::table('channel_twitter_profiles')->where('account_id', $this->account->id)->delete();
+        DB::table('channel_whatsapp')->where('account_id', $this->account->id)->delete();
+        DB::table('channel_sms')->where('account_id', $this->account->id)->delete();
+        DB::table('channel_email')->where('account_id', $this->account->id)->delete();
+        DB::table('channel_api')->where('account_id', $this->account->id)->delete();
+        DB::table('channel_telegram')->where('account_id', $this->account->id)->delete();
+        DB::table('channel_line')->where('account_id', $this->account->id)->delete();
+        DB::table('channel_voice')->where('account_id', $this->account->id)->delete();
 
-        \Illuminate\Support\Facades\DB::table('teams')->where('account_id', $this->account->id)->delete();
-        \Illuminate\Support\Facades\DB::table('conversations')->where('account_id', $this->account->id)->delete();
-        \Illuminate\Support\Facades\DB::table('labelings')->whereIn('label_id', function ($query) {
+        DB::table('teams')->where('account_id', $this->account->id)->delete();
+        DB::table('conversations')->where('account_id', $this->account->id)->delete();
+        DB::table('labelings')->whereIn('label_id', function ($query) {
             $query->select('id')->from('labels')->where('account_id', $this->account->id);
         })->delete();
-        \Illuminate\Support\Facades\DB::table('labels')->where('account_id', $this->account->id)->delete();
-        \Illuminate\Support\Facades\DB::table('inboxes')->where('account_id', $this->account->id)->delete();
-        \Illuminate\Support\Facades\DB::table('contacts')->where('account_id', $this->account->id)->delete();
-        \Illuminate\Support\Facades\DB::table('custom_roles')->where('account_id', $this->account->id)->delete();
-        \Illuminate\Support\Facades\DB::table('canned_responses')->where('account_id', $this->account->id)->delete();
+        DB::table('labels')->where('account_id', $this->account->id)->delete();
+        DB::table('inboxes')->where('account_id', $this->account->id)->delete();
+        DB::table('contacts')->where('account_id', $this->account->id)->delete();
+        DB::table('custom_roles')->where('account_id', $this->account->id)->delete();
+        DB::table('canned_responses')->where('account_id', $this->account->id)->delete();
 
-        \Illuminate\Support\Facades\DB::table('users')
+        DB::table('users')
             ->where('email', 'like', '%@paperlayer.test')
             ->whereNotExists(function ($query) {
                 $query->selectRaw('1')

--- a/laravel-svelte-port/laravel/routes/api.php
+++ b/laravel-svelte-port/laravel/routes/api.php
@@ -540,6 +540,7 @@ Route::middleware(['auth:sanctum', 'validate.bot.access'])->group(function () {
             Route::get('inboxes', [\App\Http\Controllers\Api\V2\ReportsController::class, 'inboxes']);
             Route::get('labels', [\App\Http\Controllers\Api\V2\ReportsController::class, 'labels']);
             Route::get('teams', [\App\Http\Controllers\Api\V2\ReportsController::class, 'teams']);
+            Route::get('conversations_summary', [\App\Http\Controllers\Api\V2\ReportsController::class, 'conversationsSummary']);
             Route::get('conversation_traffic', [\App\Http\Controllers\Api\V2\ReportsController::class, 'conversationTraffic']);
             Route::get('conversations', [\App\Http\Controllers\Api\V2\ReportsController::class, 'conversations']);
             Route::get('bot_metrics', [\App\Http\Controllers\Api\V2\ReportsController::class, 'botMetrics']);
@@ -555,13 +556,6 @@ Route::middleware(['auth:sanctum', 'validate.bot.access'])->group(function () {
         Route::prefix('v2/agents')->group(function () {
             Route::get('status', [\App\Http\Controllers\Api\V2\AgentsController::class, 'status']);
         });
-
-        // Reports V2 - Heatmap data and CSV exports
-        Route::prefix('v2/reports')->group(function () {
-            Route::get('/', [\App\Http\Controllers\Api\V2\ReportsController::class, 'index']); // Heatmap timeseries data
-            Route::get('conversation_traffic', [\App\Http\Controllers\Api\V2\ReportsController::class, 'conversationTraffic']); // CSV export
-        });
-
         // Summary Reports V2 - Detailed summary reports by entity type
         Route::prefix('v2/summary_reports')->group(function () {
             Route::get('agent', [\App\Http\Controllers\Api\V2\SummaryReportsController::class, 'agent']);

--- a/laravel-svelte-port/svelte-ui/src/lib/api/agents.ts
+++ b/laravel-svelte-port/svelte-ui/src/lib/api/agents.ts
@@ -12,7 +12,7 @@ export interface Agent {
   avatarUrl?: string;
   confirmed: boolean;
   accountId: number;
-  customAttributes?: Record<string, any>;
+  customAttributes?: Record<string, unknown>;
 }
 
 export interface AgentListParams {
@@ -48,7 +48,8 @@ export async function getAgents(
   const query = searchParams.toString();
   const url = `api/v1/accounts/${accountId}/agents${query ? `?${query}` : ''}`;
 
-  return api.get(url).json();
+  const response = await api.get(url).json<{ data: Agent[] }>();
+  return response.data;
 }
 
 /**
@@ -58,7 +59,10 @@ export async function getAgent(
   accountId: number,
   agentId: number
 ): Promise<Agent> {
-  return api.get(`api/v1/accounts/${accountId}/agents/${agentId}`).json();
+  const response = await api
+    .get(`api/v1/accounts/${accountId}/agents/${agentId}`)
+    .json<{ data: Agent }>();
+  return response.data;
 }
 
 /**
@@ -68,9 +72,10 @@ export async function createAgent(
   accountId: number,
   data: CreateAgentParams
 ): Promise<Agent> {
-  return api
+  const response = await api
     .post(`api/v1/accounts/${accountId}/agents`, { json: data })
-    .json();
+    .json<{ data: Agent }>();
+  return response.data;
 }
 
 /**
@@ -81,9 +86,10 @@ export async function updateAgent(
   agentId: number,
   data: UpdateAgentParams
 ): Promise<Agent> {
-  return api
+  const response = await api
     .patch(`api/v1/accounts/${accountId}/agents/${agentId}`, { json: data })
-    .json();
+    .json<{ data: Agent }>();
+  return response.data;
 }
 
 /**

--- a/laravel-svelte-port/svelte-ui/src/lib/api/client.ts
+++ b/laravel-svelte-port/svelte-ui/src/lib/api/client.ts
@@ -3,10 +3,10 @@
  * Replaces axios from Vue application with modern ky-based client
  */
 
-import ky, { type KyInstance, type Options } from 'ky';
+import ky, { type KyInstance } from 'ky';
 import { keysToCamel, keysToSnake } from './transformers';
 import { ApiError, NetworkError, handleHttpError } from './errors';
-import type { RequestOptions, UploadOptions, UploadProgressCallback } from './types';
+import type { RequestOptions, UploadOptions } from './types';
 
 /**
  * Get auth token from storage
@@ -15,7 +15,7 @@ function getAuthToken(): string | null {
   if (typeof localStorage === 'undefined') return null;
   try {
     return localStorage.getItem('auth_token');
-  } catch (e) {
+  } catch {
     return null;
   }
 }
@@ -24,7 +24,11 @@ function getAuthToken(): string | null {
  * Create base ky instance with configuration
  */
 const createApiClient = (): KyInstance => {
-  const baseUrl = import.meta.env.VITE_API_BASE_URL || 'http://localhost:8000';
+  const baseUrl =
+    import.meta.env.VITE_API_BASE_URL ||
+    (typeof window !== 'undefined'
+      ? window.location.origin
+      : 'http://127.0.0.1:8000');
 
   return ky.create({
     prefixUrl: baseUrl,
@@ -33,7 +37,7 @@ const createApiClient = (): KyInstance => {
       limit: 3,
       methods: ['get'],
       statusCodes: [408, 413, 429, 500, 502, 503, 504],
-      backoffLimit: 30000
+      backoffLimit: 30000,
     },
     hooks: {
       beforeRequest: [
@@ -54,29 +58,32 @@ const createApiClient = (): KyInstance => {
             !options.skipTransform
           ) {
             const contentType = request.headers.get('content-type');
-            
+
             // Only transform JSON bodies
             if (!contentType || contentType.includes('application/json')) {
               try {
                 // Handle both string and ReadableStream bodies
-                const bodyContent = typeof request.body === 'string' 
-                  ? request.body 
-                  : (request.body ? await new Response(request.body).text() : '');
-                
+                const bodyContent =
+                  typeof request.body === 'string'
+                    ? request.body
+                    : request.body
+                      ? await new Response(request.body).text()
+                      : '';
+
                 if (bodyContent) {
                   const data = JSON.parse(bodyContent);
                   const transformed = keysToSnake(data);
                   request.headers.set('content-type', 'application/json');
                   return new Request(request, {
-                    body: JSON.stringify(transformed)
+                    body: JSON.stringify(transformed),
                   });
                 }
-              } catch (e) {
+              } catch {
                 // Body is not JSON, leave as is
               }
             }
           }
-        }
+        },
       ],
       afterResponse: [
         async (request, options: RequestOptions, response) => {
@@ -93,34 +100,36 @@ const createApiClient = (): KyInstance => {
                 const data = await response.json();
                 const transformed = keysToCamel(data);
                 return new Response(JSON.stringify(transformed), response);
-              } catch (e) {
+              } catch {
                 // Response is not JSON or already consumed
                 return response;
               }
             }
           }
-          
+
           return response;
-        }
+        },
       ],
       beforeError: [
-        async (error) => {
+        async error => {
           const { request, response } = error;
-          
+
           if (!response) {
             // Network error
-            throw new NetworkError('Network error: Unable to connect to server');
+            throw new NetworkError(
+              'Network error: Unable to connect to server'
+            );
           }
 
           // Handle specific error status codes
           const endpoint = request.url;
-          
+
           if (response.status === 401) {
             // Clear auth token on 401
             if (typeof localStorage !== 'undefined') {
               localStorage.removeItem('auth_token');
             }
-            
+
             // Redirect to login if in browser
             if (typeof window !== 'undefined' && window.location) {
               window.location.href = '/login';
@@ -129,12 +138,12 @@ const createApiClient = (): KyInstance => {
 
           // Parse and throw ApiError
           await handleHttpError(response, endpoint);
-          
+
           // Return the error to satisfy the hook type
           return error;
-        }
-      ]
-    }
+        },
+      ],
+    },
   });
 };
 
@@ -150,7 +159,7 @@ export async function uploadFile(
   endpoint: string,
   file: File | FormData,
   options: UploadOptions = {}
-): Promise<any> {
+): Promise<unknown> {
   const formData = file instanceof FormData ? file : new FormData();
   if (file instanceof File) {
     formData.append('file', file);
@@ -160,14 +169,21 @@ export async function uploadFile(
   return new Promise((resolve, reject) => {
     const xhr = new XMLHttpRequest();
     const token = getAuthToken();
-    const baseUrl = import.meta.env.VITE_API_BASE_URL || 'http://localhost:3000';
+    const baseUrl =
+      import.meta.env.VITE_API_BASE_URL ||
+      (typeof window !== 'undefined'
+        ? `${window.location.origin}/`
+        : 'http://127.0.0.1:8000/');
 
-    xhr.open(options.method || 'POST', `${baseUrl}/${endpoint}`);
-    
+    const normalizedBaseUrl = baseUrl.endsWith('/')
+      ? baseUrl.slice(0, -1)
+      : baseUrl;
+    xhr.open(options.method || 'POST', `${normalizedBaseUrl}/${endpoint}`);
+
     if (token) {
       xhr.setRequestHeader('Authorization', `Bearer ${token}`);
     }
-    
+
     if (options.headers) {
       Object.entries(options.headers).forEach(([key, value]) => {
         xhr.setRequestHeader(key, value);
@@ -176,7 +192,7 @@ export async function uploadFile(
 
     // Progress tracking
     if (options.onProgress) {
-      xhr.upload.addEventListener('progress', (e) => {
+      xhr.upload.addEventListener('progress', e => {
         if (e.lengthComputable) {
           const progress = (e.loaded / e.total) * 100;
           options.onProgress?.(progress);
@@ -190,14 +206,20 @@ export async function uploadFile(
         try {
           const response = JSON.parse(xhr.responseText);
           resolve(keysToCamel(response));
-        } catch (e) {
+        } catch {
           resolve(xhr.responseText);
         }
       } else {
         try {
           const errorData = JSON.parse(xhr.responseText);
-          reject(new ApiError(xhr.status, errorData.message || 'Upload failed', errorData));
-        } catch (e) {
+          reject(
+            new ApiError(
+              xhr.status,
+              errorData.message || 'Upload failed',
+              errorData
+            )
+          );
+        } catch {
           reject(new ApiError(xhr.status, 'Upload failed'));
         }
       }
@@ -226,16 +248,16 @@ export async function uploadFile(
 /**
  * Helper to create query string from params
  */
-export function buildQueryString(params: Record<string, any>): string {
+export function buildQueryString(params: Record<string, unknown>): string {
   const transformed = keysToSnake(params);
   const searchParams = new URLSearchParams();
-  
+
   Object.entries(transformed).forEach(([key, value]) => {
     if (value !== undefined && value !== null) {
       searchParams.append(key, String(value));
     }
   });
-  
+
   const queryString = searchParams.toString();
   return queryString ? `?${queryString}` : '';
 }
@@ -247,15 +269,17 @@ export function buildQueryString(params: Record<string, any>): string {
  * Keys are automatically transformed to snake_case
  * Returns undefined if params is undefined or empty
  */
-export function toSearchParams(params?: Record<string, any>): Record<string, string> | undefined {
+export function toSearchParams<T extends object>(
+  params?: T
+): Record<string, string> | undefined {
   if (!params || Object.keys(params).length === 0) {
     return undefined;
   }
-  
+
   // Transform keys to snake_case first
   const transformed = keysToSnake(params);
   const result: Record<string, string> = {};
-  
+
   Object.entries(transformed).forEach(([key, value]) => {
     if (value !== undefined && value !== null) {
       if (typeof value === 'boolean') {
@@ -269,7 +293,7 @@ export function toSearchParams(params?: Record<string, any>): Record<string, str
       }
     }
   });
-  
+
   return Object.keys(result).length > 0 ? result : undefined;
 }
 

--- a/laravel-svelte-port/svelte-ui/src/lib/api/reports.ts
+++ b/laravel-svelte-port/svelte-ui/src/lib/api/reports.ts
@@ -49,22 +49,19 @@ export interface ReportsResponse {
 
 // Live metrics interfaces
 export interface LiveConversationMetricsResponse {
-  data: {
-    open: number;
-    unattended: number;
-    unassigned: number;
-    pending: number;
-  };
+  open: number;
+  unattended: number;
+  unassigned: number;
+  pending: number;
 }
 
-export interface LiveGroupedConversationsResponse {
-  data: Array<{
-    assigneeId?: number;
-    teamId?: number;
-    open: number;
-    unattended: number;
-  }>;
-}
+export type LiveGroupedConversationsResponse = Array<{
+  assignee_id?: number;
+  team_id?: number;
+  open: number;
+  unattended: number;
+  unassigned: number;
+}>;
 
 export interface AgentStatusResponse {
   data: {
@@ -88,9 +85,11 @@ export async function getAccountReports(
   accountId: number,
   filters: ReportFilters = {}
 ): Promise<ReportsResponse> {
-  return api.get(`api/v1/accounts/${accountId}/v2/reports`, {
-    searchParams: toSearchParams(filters)
-  }).json();
+  return api
+    .get(`api/v1/accounts/${accountId}/v2/reports`, {
+      searchParams: toSearchParams(filters),
+    })
+    .json();
 }
 
 /**
@@ -100,9 +99,11 @@ export async function getAgentReports(
   accountId: number,
   filters: ReportFilters = {}
 ): Promise<ReportsResponse> {
-  return api.get(`api/v1/accounts/${accountId}/v2/reports/agents`, {
-    searchParams: toSearchParams(filters)
-  }).json();
+  return api
+    .get(`api/v1/accounts/${accountId}/v2/summary_reports/agent`, {
+      searchParams: toSearchParams(filters),
+    })
+    .json();
 }
 
 /**
@@ -112,9 +113,11 @@ export async function getTeamReports(
   accountId: number,
   filters: ReportFilters = {}
 ): Promise<ReportsResponse> {
-  return api.get(`api/v1/accounts/${accountId}/v2/reports/teams`, {
-    searchParams: toSearchParams(filters)
-  }).json();
+  return api
+    .get(`api/v1/accounts/${accountId}/v2/summary_reports/team`, {
+      searchParams: toSearchParams(filters),
+    })
+    .json();
 }
 
 /**
@@ -124,9 +127,11 @@ export async function getLabelReports(
   accountId: number,
   filters: ReportFilters = {}
 ): Promise<ReportsResponse> {
-  return api.get(`api/v1/accounts/${accountId}/v2/reports/labels`, {
-    searchParams: toSearchParams(filters)
-  }).json();
+  return api
+    .get(`api/v1/accounts/${accountId}/v2/summary_reports/label`, {
+      searchParams: toSearchParams(filters),
+    })
+    .json();
 }
 
 /**
@@ -136,9 +141,11 @@ export async function getInboxReports(
   accountId: number,
   filters: ReportFilters = {}
 ): Promise<ReportsResponse> {
-  return api.get(`api/v1/accounts/${accountId}/v2/reports/inboxes`, {
-    searchParams: toSearchParams(filters)
-  }).json();
+  return api
+    .get(`api/v1/accounts/${accountId}/v2/summary_reports/inbox`, {
+      searchParams: toSearchParams(filters),
+    })
+    .json();
 }
 
 /**
@@ -148,9 +155,11 @@ export async function getConversationSummary(
   accountId: number,
   filters: ReportFilters = {}
 ): Promise<any> {
-  return api.get(`api/v1/accounts/${accountId}/v2/reports/summary`, {
-    searchParams: toSearchParams(filters)
-  }).json();
+  return api
+    .get(`api/v1/accounts/${accountId}/v2/reports/summary`, {
+      searchParams: toSearchParams(filters),
+    })
+    .json();
 }
 
 /**
@@ -164,9 +173,11 @@ export async function getLiveConversationMetrics(
   accountId: number,
   params: { teamId?: number } = {}
 ): Promise<LiveConversationMetricsResponse> {
-  return api.get(`api/v1/accounts/${accountId}/v2/live_reports/conversation_metrics`, {
-    searchParams: toSearchParams(params)
-  }).json();
+  return api
+    .get(`api/v1/accounts/${accountId}/v2/live_reports/conversation_metrics`, {
+      searchParams: toSearchParams({ team_id: params.teamId }),
+    })
+    .json();
 }
 
 /**
@@ -176,9 +187,14 @@ export async function getLiveGroupedConversations(
   accountId: number,
   params: { groupBy: 'assignee_id' | 'team_id' }
 ): Promise<LiveGroupedConversationsResponse> {
-  return api.get(`api/v1/accounts/${accountId}/v2/live_reports/grouped_conversation_metrics`, {
-    searchParams: toSearchParams(params)
-  }).json();
+  return api
+    .get(
+      `api/v1/accounts/${accountId}/v2/live_reports/grouped_conversation_metrics`,
+      {
+        searchParams: toSearchParams({ group_by: params.groupBy }),
+      }
+    )
+    .json();
 }
 
 /**
@@ -205,18 +221,20 @@ export async function getHeatmapData(
     id?: number;
   }
 ): Promise<HeatmapDataResponse> {
-  return api.get(`api/v1/accounts/${accountId}/v2/reports`, {
-    searchParams: toSearchParams({
-      metric: params.metric,
-      since: params.from,
-      until: params.to,
-      group_by: params.groupBy,
-      business_hours: params.businessHours,
-      type: params.type,
-      id: params.id,
-      timezone_offset: -new Date().getTimezoneOffset() / 60
+  return api
+    .get(`api/v1/accounts/${accountId}/v2/reports`, {
+      searchParams: toSearchParams({
+        metric: params.metric,
+        since: params.from,
+        until: params.to,
+        group_by: params.groupBy,
+        business_hours: params.businessHours,
+        type: params.type,
+        id: params.id,
+        timezone_offset: -new Date().getTimezoneOffset() / 60,
+      }),
     })
-  }).json();
+    .json();
 }
 
 /**
@@ -226,12 +244,15 @@ export async function downloadConversationTrafficCSV(
   accountId: number,
   params: { daysBefore: number; to?: number }
 ): Promise<void> {
-  const response = await api.get(`api/v1/accounts/${accountId}/v2/reports/conversation_traffic`, {
-    searchParams: toSearchParams({
-      days_before: params.daysBefore,
-      timezone_offset: -new Date().getTimezoneOffset() / 60
-    })
-  });
+  const response = await api.get(
+    `api/v1/accounts/${accountId}/v2/reports/conversation_traffic`,
+    {
+      searchParams: toSearchParams({
+        days_before: params.daysBefore,
+        timezone_offset: -new Date().getTimezoneOffset() / 60,
+      }),
+    }
+  );
 
   // Handle CSV download
   const blob = await response.blob();
@@ -259,17 +280,19 @@ export async function getAccountSummary(
     businessHours?: boolean;
   }
 ): Promise<ReportsResponse> {
-  return api.get(`api/v1/accounts/${accountId}/v2/reports/summary`, {
-    searchParams: toSearchParams({
-      since: params.from,
-      until: params.to,
-      type: params.type,
-      id: params.id,
-      group_by: params.groupBy,
-      business_hours: params.businessHours,
-      timezone_offset: -new Date().getTimezoneOffset() / 60
+  return api
+    .get(`api/v1/accounts/${accountId}/v2/reports/summary`, {
+      searchParams: toSearchParams({
+        since: params.from,
+        until: params.to,
+        type: params.type,
+        id: params.id,
+        group_by: params.groupBy,
+        business_hours: params.businessHours,
+        timezone_offset: -new Date().getTimezoneOffset() / 60,
+      }),
     })
-  }).json();
+    .json();
 }
 
 /**
@@ -287,18 +310,20 @@ export async function getAccountReport(
     businessHours?: boolean;
   }
 ): Promise<ReportsResponse> {
-  return api.get(`api/v1/accounts/${accountId}/v2/reports`, {
-    searchParams: toSearchParams({
-      metric: params.metric,
-      since: params.from,
-      until: params.to,
-      type: params.type,
-      id: params.id,
-      group_by: params.groupBy,
-      business_hours: params.businessHours,
-      timezone_offset: -new Date().getTimezoneOffset() / 60
+  return api
+    .get(`api/v1/accounts/${accountId}/v2/reports`, {
+      searchParams: toSearchParams({
+        metric: params.metric,
+        since: params.from,
+        until: params.to,
+        type: params.type,
+        id: params.id,
+        group_by: params.groupBy,
+        business_hours: params.businessHours,
+        timezone_offset: -new Date().getTimezoneOffset() / 60,
+      }),
     })
-  }).json();
+    .json();
 }
 
 /**
@@ -315,17 +340,19 @@ export async function getBotSummary(
     businessHours?: boolean;
   }
 ): Promise<ReportsResponse> {
-  return api.get(`api/v1/accounts/${accountId}/v2/reports/bots/summary`, {
-    searchParams: toSearchParams({
-      since: params.from,
-      until: params.to,
-      type: params.type,
-      id: params.id,
-      group_by: params.groupBy,
-      business_hours: params.businessHours,
-      timezone_offset: -new Date().getTimezoneOffset() / 60
+  return api
+    .get(`api/v1/accounts/${accountId}/v2/reports/bot_summary`, {
+      searchParams: toSearchParams({
+        since: params.from,
+        until: params.to,
+        type: params.type,
+        id: params.id,
+        group_by: params.groupBy,
+        business_hours: params.businessHours,
+        timezone_offset: -new Date().getTimezoneOffset() / 60,
+      }),
     })
-  }).json();
+    .json();
 }
 
 /**
@@ -340,21 +367,26 @@ export async function downloadConversationsSummary(
     businessHours?: boolean;
   }
 ): Promise<void> {
-  const response = await api.get(`api/v1/accounts/${accountId}/v2/reports/conversations/download`, {
-    searchParams: toSearchParams({
-      since: params.from,
-      until: params.to,
-      business_hours: params.businessHours,
-      timezone_offset: -new Date().getTimezoneOffset() / 60
-    })
-  });
+  const response = await api.get(
+    `api/v1/accounts/${accountId}/v2/reports/conversations_summary`,
+    {
+      searchParams: toSearchParams({
+        since: params.from,
+        until: params.to,
+        business_hours: params.businessHours,
+        timezone_offset: -new Date().getTimezoneOffset() / 60,
+      }),
+    }
+  );
 
   // Handle CSV download
   const blob = await response.blob();
   const url = window.URL.createObjectURL(blob);
   const a = document.createElement('a');
   a.href = url;
-  a.download = params.fileName || `conversations_summary_${new Date().toISOString().split('T')[0]}.csv`;
+  a.download =
+    params.fileName ||
+    `conversations_summary_${new Date().toISOString().split('T')[0]}.csv`;
   document.body.appendChild(a);
   a.click();
   document.body.removeChild(a);
@@ -373,13 +405,16 @@ export async function downloadAgentReports(
     businessHours?: boolean;
   }
 ): Promise<string> {
-  const response = await api.get(`api/v1/accounts/${accountId}/v2/reports/agents`, {
-    searchParams: toSearchParams({
-      since: params.from,
-      until: params.to,
-      business_hours: params.businessHours
-    })
-  });
+  const response = await api.get(
+    `api/v1/accounts/${accountId}/v2/summary_reports/agent`,
+    {
+      searchParams: toSearchParams({
+        since: params.from,
+        until: params.to,
+        business_hours: params.businessHours,
+      }),
+    }
+  );
 
   return response.text();
 }
@@ -396,13 +431,16 @@ export async function downloadLabelReports(
     businessHours?: boolean;
   }
 ): Promise<string> {
-  const response = await api.get(`api/v1/accounts/${accountId}/v2/reports/labels`, {
-    searchParams: toSearchParams({
-      since: params.from,
-      until: params.to,
-      business_hours: params.businessHours
-    })
-  });
+  const response = await api.get(
+    `api/v1/accounts/${accountId}/v2/summary_reports/label`,
+    {
+      searchParams: toSearchParams({
+        since: params.from,
+        until: params.to,
+        business_hours: params.businessHours,
+      }),
+    }
+  );
 
   return response.text();
 }
@@ -419,13 +457,16 @@ export async function downloadInboxReports(
     businessHours?: boolean;
   }
 ): Promise<string> {
-  const response = await api.get(`api/v1/accounts/${accountId}/v2/reports/inboxes`, {
-    searchParams: toSearchParams({
-      since: params.from,
-      until: params.to,
-      business_hours: params.businessHours
-    })
-  });
+  const response = await api.get(
+    `api/v1/accounts/${accountId}/v2/summary_reports/inbox`,
+    {
+      searchParams: toSearchParams({
+        since: params.from,
+        until: params.to,
+        business_hours: params.businessHours,
+      }),
+    }
+  );
 
   return response.text();
 }
@@ -442,13 +483,16 @@ export async function downloadTeamReports(
     businessHours?: boolean;
   }
 ): Promise<string> {
-  const response = await api.get(`api/v1/accounts/${accountId}/v2/reports/teams`, {
-    searchParams: toSearchParams({
-      since: params.from,
-      until: params.to,
-      business_hours: params.businessHours
-    })
-  });
+  const response = await api.get(
+    `api/v1/accounts/${accountId}/v2/summary_reports/team`,
+    {
+      searchParams: toSearchParams({
+        since: params.from,
+        until: params.to,
+        business_hours: params.businessHours,
+      }),
+    }
+  );
 
   return response.text();
 }

--- a/laravel-svelte-port/svelte-ui/src/lib/api/reports.ts
+++ b/laravel-svelte-port/svelte-ui/src/lib/api/reports.ts
@@ -99,11 +99,13 @@ export async function getAgentReports(
   accountId: number,
   filters: ReportFilters = {}
 ): Promise<ReportsResponse> {
-  return api
+  const response = (await api
     .get(`api/v1/accounts/${accountId}/v2/summary_reports/agent`, {
       searchParams: toSearchParams(filters),
     })
-    .json();
+    .json()) as { agents?: AgentMetrics[] };
+
+  return { data: response.agents || [] };
 }
 
 /**
@@ -113,11 +115,13 @@ export async function getTeamReports(
   accountId: number,
   filters: ReportFilters = {}
 ): Promise<ReportsResponse> {
-  return api
+  const response = (await api
     .get(`api/v1/accounts/${accountId}/v2/summary_reports/team`, {
       searchParams: toSearchParams(filters),
     })
-    .json();
+    .json()) as { teams?: TeamMetrics[] };
+
+  return { data: response.teams || [] };
 }
 
 /**
@@ -127,11 +131,13 @@ export async function getLabelReports(
   accountId: number,
   filters: ReportFilters = {}
 ): Promise<ReportsResponse> {
-  return api
+  const response = (await api
     .get(`api/v1/accounts/${accountId}/v2/summary_reports/label`, {
       searchParams: toSearchParams(filters),
     })
-    .json();
+    .json()) as { labels?: AgentMetrics[] };
+
+  return { data: response.labels || [] };
 }
 
 /**
@@ -141,11 +147,13 @@ export async function getInboxReports(
   accountId: number,
   filters: ReportFilters = {}
 ): Promise<ReportsResponse> {
-  return api
+  const response = (await api
     .get(`api/v1/accounts/${accountId}/v2/summary_reports/inbox`, {
       searchParams: toSearchParams(filters),
     })
-    .json();
+    .json()) as { inboxes?: AgentMetrics[] };
+
+  return { data: response.inboxes || [] };
 }
 
 /**

--- a/laravel-svelte-port/svelte-ui/src/lib/api/reports.ts
+++ b/laravel-svelte-port/svelte-ui/src/lib/api/reports.ts
@@ -6,6 +6,29 @@
 
 import api, { toSearchParams } from './client';
 
+const getTimezoneOffset = () => -new Date().getTimezoneOffset() / 60;
+
+function buildReportParams(params: {
+  from?: number;
+  to?: number;
+  type?: string;
+  id?: number;
+  groupBy?: string;
+  businessHours?: boolean;
+  metric?: string;
+}) {
+  return toSearchParams({
+    metric: params.metric,
+    since: params.from,
+    until: params.to,
+    type: params.type,
+    id: params.id,
+    group_by: params.groupBy,
+    business_hours: params.businessHours,
+    timezone_offset: getTimezoneOffset(),
+  });
+}
+
 export interface ConversationMetrics {
   totalConversations: number;
   openConversations: number;
@@ -162,7 +185,7 @@ export async function getInboxReports(
 export async function getConversationSummary(
   accountId: number,
   filters: ReportFilters = {}
-): Promise<any> {
+): Promise<ReportsResponse> {
   return api
     .get(`api/v1/accounts/${accountId}/v2/reports/summary`, {
       searchParams: toSearchParams(filters),
@@ -231,16 +254,7 @@ export async function getHeatmapData(
 ): Promise<HeatmapDataResponse> {
   return api
     .get(`api/v1/accounts/${accountId}/v2/reports`, {
-      searchParams: toSearchParams({
-        metric: params.metric,
-        since: params.from,
-        until: params.to,
-        group_by: params.groupBy,
-        business_hours: params.businessHours,
-        type: params.type,
-        id: params.id,
-        timezone_offset: -new Date().getTimezoneOffset() / 60,
-      }),
+      searchParams: buildReportParams(params),
     })
     .json();
 }
@@ -257,7 +271,7 @@ export async function downloadConversationTrafficCSV(
     {
       searchParams: toSearchParams({
         days_before: params.daysBefore,
-        timezone_offset: -new Date().getTimezoneOffset() / 60,
+        timezone_offset: getTimezoneOffset(),
       }),
     }
   );
@@ -290,15 +304,7 @@ export async function getAccountSummary(
 ): Promise<ReportsResponse> {
   return api
     .get(`api/v1/accounts/${accountId}/v2/reports/summary`, {
-      searchParams: toSearchParams({
-        since: params.from,
-        until: params.to,
-        type: params.type,
-        id: params.id,
-        group_by: params.groupBy,
-        business_hours: params.businessHours,
-        timezone_offset: -new Date().getTimezoneOffset() / 60,
-      }),
+      searchParams: buildReportParams(params),
     })
     .json();
 }
@@ -320,16 +326,7 @@ export async function getAccountReport(
 ): Promise<ReportsResponse> {
   return api
     .get(`api/v1/accounts/${accountId}/v2/reports`, {
-      searchParams: toSearchParams({
-        metric: params.metric,
-        since: params.from,
-        until: params.to,
-        type: params.type,
-        id: params.id,
-        group_by: params.groupBy,
-        business_hours: params.businessHours,
-        timezone_offset: -new Date().getTimezoneOffset() / 60,
-      }),
+      searchParams: buildReportParams(params),
     })
     .json();
 }
@@ -350,15 +347,7 @@ export async function getBotSummary(
 ): Promise<ReportsResponse> {
   return api
     .get(`api/v1/accounts/${accountId}/v2/reports/bot_summary`, {
-      searchParams: toSearchParams({
-        since: params.from,
-        until: params.to,
-        type: params.type,
-        id: params.id,
-        group_by: params.groupBy,
-        business_hours: params.businessHours,
-        timezone_offset: -new Date().getTimezoneOffset() / 60,
-      }),
+      searchParams: buildReportParams(params),
     })
     .json();
 }
@@ -382,7 +371,7 @@ export async function downloadConversationsSummary(
         since: params.from,
         until: params.to,
         business_hours: params.businessHours,
-        timezone_offset: -new Date().getTimezoneOffset() / 60,
+        timezone_offset: getTimezoneOffset(),
       }),
     }
   );
@@ -414,7 +403,7 @@ export async function downloadAgentReports(
   }
 ): Promise<string> {
   const response = await api.get(
-    `api/v1/accounts/${accountId}/v2/summary_reports/agent`,
+    `api/v1/accounts/${accountId}/v2/reports/agents`,
     {
       searchParams: toSearchParams({
         since: params.from,
@@ -440,7 +429,7 @@ export async function downloadLabelReports(
   }
 ): Promise<string> {
   const response = await api.get(
-    `api/v1/accounts/${accountId}/v2/summary_reports/label`,
+    `api/v1/accounts/${accountId}/v2/reports/labels`,
     {
       searchParams: toSearchParams({
         since: params.from,
@@ -466,7 +455,7 @@ export async function downloadInboxReports(
   }
 ): Promise<string> {
   const response = await api.get(
-    `api/v1/accounts/${accountId}/v2/summary_reports/inbox`,
+    `api/v1/accounts/${accountId}/v2/reports/inboxes`,
     {
       searchParams: toSearchParams({
         since: params.from,
@@ -492,7 +481,7 @@ export async function downloadTeamReports(
   }
 ): Promise<string> {
   const response = await api.get(
-    `api/v1/accounts/${accountId}/v2/summary_reports/team`,
+    `api/v1/accounts/${accountId}/v2/reports/teams`,
     {
       searchParams: toSearchParams({
         since: params.from,

--- a/laravel-svelte-port/svelte-ui/src/lib/api/reports.ts
+++ b/laravel-svelte-port/svelte-ui/src/lib/api/reports.ts
@@ -414,7 +414,7 @@ export async function downloadAgentReports(
   }
 ): Promise<string> {
   const response = await api.get(
-    `api/v1/accounts/${accountId}/v2/summary_reports/agent`,
+    `api/v1/accounts/${accountId}/v2/reports/agents`,
     {
       searchParams: toSearchParams({
         since: params.from,
@@ -440,7 +440,7 @@ export async function downloadLabelReports(
   }
 ): Promise<string> {
   const response = await api.get(
-    `api/v1/accounts/${accountId}/v2/summary_reports/label`,
+    `api/v1/accounts/${accountId}/v2/reports/labels`,
     {
       searchParams: toSearchParams({
         since: params.from,
@@ -466,7 +466,7 @@ export async function downloadInboxReports(
   }
 ): Promise<string> {
   const response = await api.get(
-    `api/v1/accounts/${accountId}/v2/summary_reports/inbox`,
+    `api/v1/accounts/${accountId}/v2/reports/inboxes`,
     {
       searchParams: toSearchParams({
         since: params.from,
@@ -492,7 +492,7 @@ export async function downloadTeamReports(
   }
 ): Promise<string> {
   const response = await api.get(
-    `api/v1/accounts/${accountId}/v2/summary_reports/team`,
+    `api/v1/accounts/${accountId}/v2/reports/teams`,
     {
       searchParams: toSearchParams({
         since: params.from,

--- a/laravel-svelte-port/svelte-ui/src/lib/components/layout/AppSidebar.svelte
+++ b/laravel-svelte-port/svelte-ui/src/lib/components/layout/AppSidebar.svelte
@@ -267,8 +267,8 @@
           {
             id: 'reports-conversation',
             label: safeT("SIDEBAR.REPORTS_CONVERSATION", 'Conversation'),
-            href: `/app/accounts/${accountId}/reports/conversations`,
-            activeOn: [`/app/accounts/${accountId}/reports/conversations`],
+            href: `/app/accounts/${accountId}/reports/conversation`,
+            activeOn: [`/app/accounts/${accountId}/reports/conversation`],
             permission: 'report_manage',
           },
           {

--- a/laravel-svelte-port/svelte-ui/src/lib/components/reports/shared/ReportChart.svelte
+++ b/laravel-svelte-port/svelte-ui/src/lib/components/reports/shared/ReportChart.svelte
@@ -6,21 +6,42 @@
     title: string;
     metricKey: string;
     isTime?: boolean;
+    groupBy?: string | null;
   }
 
   let { title, metricKey, isTime = false }: Props = $props();
 
-  const chartData = $derived(reportsStore.getChartData(metricKey));
+  const rawChartData = $derived(reportsStore.getChartData(metricKey));
   const isLoading = $derived(reportsStore.getUIFlag(`isFetching_${metricKey}`));
 
-  const points = $derived<number[]>(
-    Array.isArray(chartData?.data) ? chartData.data : []
-  );
+  const chartData = $derived.by<{ data: number[]; labels: string[] }>(() => {
+    if (
+      rawChartData &&
+      Array.isArray(rawChartData.data) &&
+      Array.isArray(rawChartData.labels)
+    ) {
+      return {
+        data: rawChartData.data.map((point: unknown) => Number(point) || 0),
+        labels: rawChartData.labels.map((label: unknown) => String(label ?? '')),
+      };
+    }
 
-  const labels = $derived<string[]>(
-    Array.isArray(chartData?.labels) ? chartData.labels : []
-  );
+    const fallbackValue = Number(
+      (rawChartData as Record<string, unknown> | null)?.[metricKey]
+    );
 
+    if (!Number.isFinite(fallbackValue)) {
+      return { data: [], labels: [] };
+    }
+
+    return {
+      data: [fallbackValue],
+      labels: ['Total'],
+    };
+  });
+
+  const points = $derived<number[]>(chartData.data);
+  const labels = $derived<string[]>(chartData.labels);
   const maxValue = $derived(points.length ? Math.max(...points, 1) : 1);
 
   function formatTime(seconds: number): string {

--- a/laravel-svelte-port/svelte-ui/src/lib/components/reports/shared/ReportChart.svelte
+++ b/laravel-svelte-port/svelte-ui/src/lib/components/reports/shared/ReportChart.svelte
@@ -1,116 +1,69 @@
 <script lang="ts">
   import { Card } from '$lib/components/ui/card';
   import { reportsStore } from '$lib/stores/reports.svelte';
-  import LoadingSkeleton from './LoadingSkeleton.svelte';
-  import { Line } from 'svelte-chartjs';
-  import {
-    Chart as ChartJS,
-    Title,
-    Tooltip,
-    Legend,
-    LineElement,
-    CategoryScale,
-    LinearScale,
-    PointElement,
-  } from 'chart.js';
-
-  ChartJS.register(
-    Title,
-    Tooltip,
-    Legend,
-    LineElement,
-    CategoryScale,
-    LinearScale,
-    PointElement
-  );
 
   interface Props {
     title: string;
     metricKey: string;
-    groupBy?: any;
     isTime?: boolean;
   }
 
-  let {
-    title,
-    metricKey,
-    groupBy = null,
-    isTime = false,
-  }: Props = $props();
+  let { title, metricKey, isTime = false }: Props = $props();
 
   const chartData = $derived(reportsStore.getChartData(metricKey));
   const isLoading = $derived(reportsStore.getUIFlag(`isFetching_${metricKey}`));
 
-  const data = $derived({
-    labels: chartData?.labels || [],
-    datasets: [
-      {
-        label: title,
-        data: chartData?.data || [],
-        borderColor: 'rgb(59, 130, 246)',
-        backgroundColor: 'rgba(59, 130, 246, 0.1)',
-        tension: 0.4,
-      },
-    ],
-  });
+  const points = $derived<number[]>(
+    Array.isArray(chartData?.data) ? chartData.data : []
+  );
 
-  const options = {
-    responsive: true,
-    maintainAspectRatio: false,
-    plugins: {
-      legend: {
-        display: false,
-      },
-      title: {
-        display: false,
-      },
-      tooltip: {
-        callbacks: {
-          label: (context: any) => {
-            let label = context.dataset.label || '';
-            if (label) {
-              label += ': ';
-            }
-            if (isTime) {
-              label += formatTime(context.parsed.y);
-            } else {
-              label += context.parsed.y.toLocaleString();
-            }
-            return label;
-          },
-        },
-      },
-    },
-    scales: {
-      y: {
-        beginAtZero: true,
-      },
-    },
-  };
+  const labels = $derived<string[]>(
+    Array.isArray(chartData?.labels) ? chartData.labels : []
+  );
+
+  const maxValue = $derived(points.length ? Math.max(...points, 1) : 1);
 
   function formatTime(seconds: number): string {
     const hours = Math.floor(seconds / 3600);
     const minutes = Math.floor((seconds % 3600) / 60);
     const secs = Math.floor(seconds % 60);
-    
+
     if (hours > 0) {
       return `${hours}h ${minutes}m`;
-    } else if (minutes > 0) {
-      return `${minutes}m ${secs}s`;
-    } else {
-      return `${secs}s`;
     }
+
+    if (minutes > 0) {
+      return `${minutes}m ${secs}s`;
+    }
+
+    return `${secs}s`;
+  }
+
+  function formatValue(value: number): string {
+    return isTime ? formatTime(value) : value.toLocaleString();
   }
 </script>
 
 <Card class="p-6">
   <h3 class="text-lg font-semibold mb-4">{title}</h3>
-  
+
   {#if isLoading}
     <div class="h-[300px] animate-pulse bg-muted rounded"></div>
-  {:else if chartData && chartData.data.length > 0}
-    <div class="h-[300px]">
-      <Line {data} {options} />
+  {:else if points.length > 0}
+    <div class="h-[300px] flex items-end gap-1 rounded bg-muted/20 p-3 overflow-x-auto">
+      {#each points as point, index (labels[index] ?? index)}
+        <div class="flex flex-col items-center min-w-[18px]" title={formatValue(point)}>
+          <div
+            class="w-4 rounded-t bg-primary/70 hover:bg-primary transition-colors"
+            style={`height: ${Math.max((point / maxValue) * 220, 2)}px`}
+          ></div>
+          {#if labels[index]}
+            <span class="mt-1 text-[10px] text-muted-foreground truncate max-w-[18px]">
+              {labels[index]}
+            </span>
+          {/if}
+        </div>
+      {/each}
     </div>
   {:else}
     <div class="h-[300px] flex items-center justify-center text-muted-foreground">

--- a/laravel-svelte-port/svelte-ui/src/lib/components/reports/shared/ReportChart.svelte
+++ b/laravel-svelte-port/svelte-ui/src/lib/components/reports/shared/ReportChart.svelte
@@ -71,7 +71,7 @@
     <div class="h-[300px] animate-pulse bg-muted rounded"></div>
   {:else if points.length > 0}
     <div class="h-[300px] flex items-end gap-1 rounded bg-muted/20 p-3 overflow-x-auto">
-      {#each points as point, index (labels[index] ?? index)}
+      {#each points as point, index (index)}
         <div class="flex flex-col items-center min-w-[18px]" title={formatValue(point)}>
           <div
             class="w-4 rounded-t bg-primary/70 hover:bg-primary transition-colors"

--- a/laravel-svelte-port/svelte-ui/src/lib/components/reports/shared/ReportChart.svelte
+++ b/laravel-svelte-port/svelte-ui/src/lib/components/reports/shared/ReportChart.svelte
@@ -6,7 +6,6 @@
     title: string;
     metricKey: string;
     isTime?: boolean;
-    groupBy?: string | null;
   }
 
   let { title, metricKey, isTime = false }: Props = $props();

--- a/laravel-svelte-port/svelte-ui/src/lib/components/reports/shared/ReportFilters.svelte
+++ b/laravel-svelte-port/svelte-ui/src/lib/components/reports/shared/ReportFilters.svelte
@@ -25,7 +25,9 @@
 
   // Use $derived to maintain reactive references to props
   const currentFilterId = $derived(currentFilter?.id?.toString() || '');
-  const selectedGroupById = $derived(selectedGroupByFilter?.id?.toString() || '');
+  const selectedGroupById = $derived(
+    selectedGroupByFilter?.id?.toString() || ''
+  );
 
   let selectedFilterValue = $state('');
   let selectedGroupByValue = $state('');
@@ -41,25 +43,30 @@
   });
 
   const filterLabel = $derived(
-    filterItemsList.find((item) => item.id?.toString() === selectedFilterValue)?.name || 
-    `Select ${type}`
+    filterItemsList.find(item => item.id?.toString() === selectedFilterValue)
+      ?.name || `Select ${type}`
   );
 
   const groupByLabel = $derived(
-    groupByfilterItemsList.find((item) => item.id?.toString() === selectedGroupByValue)?.groupBy || 
-    'Select grouping'
+    groupByfilterItemsList.find(
+      item => item.id?.toString() === selectedGroupByValue
+    )?.groupByKey || 'Select grouping'
   );
 
   function onFilterSelect(value: string) {
     selectedFilterValue = value;
-    const filter = filterItemsList.find((item) => item.id?.toString() === value);
+    const filter = filterItemsList.find(item => item.id?.toString() === value);
     dispatch('filter-change', filter);
   }
 
   function onGroupBySelect(value: string) {
     selectedGroupByValue = value;
-    const groupBy = groupByfilterItemsList.find((item) => item.id?.toString() === value);
-    dispatch('group-by-filter-change', groupBy);
+    const groupBy = groupByfilterItemsList.find(
+      item => item.id?.toString() === value
+    );
+    if (groupBy) {
+      dispatch('group-by-filter-change', groupBy);
+    }
   }
 
   function onDateRangeChange(event: CustomEvent) {
@@ -83,7 +90,11 @@
     <!-- Filter Selector -->
     <div class="space-y-2">
       <Label>Filter by {type}</Label>
-      <Select.Root value={selectedFilterValue} onValueChange={onFilterSelect} type="single">
+      <Select.Root
+        value={selectedFilterValue}
+        onValueChange={onFilterSelect}
+        type="single"
+      >
         <Select.Trigger>
           {filterLabel}
         </Select.Trigger>
@@ -100,14 +111,18 @@
     <!-- Group By Selector -->
     <div class="space-y-2">
       <Label>Group By</Label>
-      <Select.Root value={selectedGroupByValue} onValueChange={onGroupBySelect} type="single">
+      <Select.Root
+        value={selectedGroupByValue}
+        onValueChange={onGroupBySelect}
+        type="single"
+      >
         <Select.Trigger>
           {groupByLabel}
         </Select.Trigger>
         <Select.Content>
           {#each groupByfilterItemsList as item}
-            <Select.Item value={item.id?.toString()} label={item.groupBy}>
-              {item.groupBy}
+            <Select.Item value={item.id?.toString()} label={item.groupByKey}>
+              {item.groupByKey}
             </Select.Item>
           {/each}
         </Select.Content>

--- a/laravel-svelte-port/svelte-ui/src/lib/components/reports/shared/WootReports.svelte
+++ b/laravel-svelte-port/svelte-ui/src/lib/components/reports/shared/WootReports.svelte
@@ -63,6 +63,12 @@
     selectedFilter = selectedItemRef;
   });
 
+  $effect(() => {
+    if (!selectedFilter && filterItemsList.length) {
+      selectedFilter = filterItemsList[0];
+    }
+  });
+
   // Get filter items list from appropriate store based on type
   const filterItemsList = $derived.by(() => {
     switch (type) {
@@ -167,6 +173,10 @@
     to = newTo;
     groupByfilterItemsList = fetchFilterItems(newGroupBy);
 
+    if (!groupByfilterItemsList.length) {
+      return;
+    }
+
     const filterItems = groupByfilterItemsList.filter(
       item => item.id === groupBy.id
     );
@@ -189,6 +199,10 @@
   }
 
   function onGroupByFilterChange(event: CustomEvent) {
+    if (!event.detail?.id) {
+      return;
+    }
+
     groupBy = GROUP_BY_FILTER[event.detail.id];
     fetchAllData();
   }

--- a/laravel-svelte-port/svelte-ui/src/lib/stores/auth.svelte.ts
+++ b/laravel-svelte-port/svelte-ui/src/lib/stores/auth.svelte.ts
@@ -14,6 +14,7 @@ import type {
 } from '$lib/api/auth';
 import * as authAPI from '$lib/api/auth';
 import * as accountsAPI from '$lib/api/accounts';
+import { getErrorMessage as getApiErrorMessage } from '$lib/api/errors';
 import { clearStorage, loadFromStorage, saveToStorage } from './persistence';
 import { globalConfig } from '$lib/stores/globalConfig.svelte';
 
@@ -153,7 +154,7 @@ class AuthStore {
       if (status === 401) {
         this.clearUser();
       }
-      this.error = this.getErrorMessage(err) || 'Failed to validate session';
+      this.error = getApiErrorMessage(err) || 'Failed to validate session';
       throw err;
     }
   }
@@ -210,7 +211,7 @@ class AuthStore {
       this.setCurrentUser(user);
       this.error = null;
     } catch (err: unknown) {
-      this.error = this.getErrorMessage(err) || 'Failed to update profile';
+      this.error = getApiErrorMessage(err) || 'Failed to update profile';
       throw err;
     }
   }
@@ -224,7 +225,7 @@ class AuthStore {
       this.setCurrentUser(user);
       this.error = null;
     } catch (err: unknown) {
-      this.error = this.getErrorMessage(err) || 'Failed to update password';
+      this.error = getApiErrorMessage(err) || 'Failed to update password';
       throw err;
     }
   }
@@ -293,7 +294,7 @@ class AuthStore {
     } catch (err: unknown) {
       // Revert on error
       this.setAvailability(previousAvailability);
-      this.error = this.getErrorMessage(err) || 'Failed to update availability';
+      this.error = getApiErrorMessage(err) || 'Failed to update availability';
       throw err;
     }
   }
@@ -314,7 +315,7 @@ class AuthStore {
     } catch (err: unknown) {
       // Revert on error
       this.setAutoOffline(previousAutoOffline);
-      this.error = this.getErrorMessage(err) || 'Failed to update auto-offline';
+      this.error = getApiErrorMessage(err) || 'Failed to update auto-offline';
       throw err;
     }
   }
@@ -402,7 +403,7 @@ class AuthStore {
       this.error = null;
       return updatedAccount;
     } catch (err: unknown) {
-      this.error = this.getErrorMessage(err) || 'Failed to update account';
+      this.error = getApiErrorMessage(err) || 'Failed to update account';
       throw err;
     }
   }
@@ -417,7 +418,7 @@ class AuthStore {
       // Refresh user/account data to reflect changes
       await this.validityCheck();
     } catch (err: unknown) {
-      this.error = this.getErrorMessage(err) || 'Failed to toggle account deletion';
+      this.error = getApiErrorMessage(err) || 'Failed to toggle account deletion';
       throw err;
     }
   }
@@ -441,14 +442,6 @@ class AuthStore {
     }
 
     this.error = null;
-  }
-
-  private getErrorMessage(error: unknown): string {
-    if (error instanceof Error) {
-      return error.message;
-    }
-
-    return '';
   }
 
   // Private helper methods

--- a/laravel-svelte-port/svelte-ui/src/lib/stores/auth.svelte.ts
+++ b/laravel-svelte-port/svelte-ui/src/lib/stores/auth.svelte.ts
@@ -4,12 +4,17 @@
  */
 
 import { goto } from '$app/navigation';
+import { resolve } from '$app/paths';
 import { page } from '$app/state';
-import type { AvailabilityUpdateParams, CurrentUser, PasswordUpdateParams, ProfileUpdateParams } from '$lib/api/auth';
+import type {
+  AvailabilityUpdateParams,
+  CurrentUser,
+  PasswordUpdateParams,
+  ProfileUpdateParams,
+} from '$lib/api/auth';
 import * as authAPI from '$lib/api/auth';
 import * as accountsAPI from '$lib/api/accounts';
 import { clearStorage, loadFromStorage, saveToStorage } from './persistence';
-import { ROLES, AVAILABLE_CUSTOM_ROLE_PERMISSIONS } from '$lib/constants/permissions';
 import { globalConfig } from '$lib/stores/globalConfig.svelte';
 
 /**
@@ -28,17 +33,19 @@ const initialUser: CurrentUser = {
  */
 class AuthStore {
   // Reactive state using runes
-  currentUser = $state<CurrentUser>(loadFromStorage<CurrentUser>('current_user') || initialUser);
+  currentUser = $state<CurrentUser>(
+    loadFromStorage<CurrentUser>('current_user') || initialUser
+  );
   isFetching = $state<boolean>(true);
   error = $state<string | null>(null);
-  
+
   // Computed values using $derived
   isLoggedIn = $derived(!!this.currentUser.id);
   currentUserId = $derived(this.currentUser.id);
   uiSettings = $derived(this.currentUser.uiSettings || {});
   messageSignature = $derived(this.currentUser.messageSignature || '');
   userAccounts = $derived(this.currentUser.accounts || []);
-  
+
   /**
    * Get current account ID from route params
    */
@@ -46,7 +53,7 @@ class AuthStore {
     const accountId = page.params?.accountId;
     return accountId ? Number(accountId) : null;
   }
-  
+
   /**
    * Get current account from accounts list
    */
@@ -61,21 +68,21 @@ class AuthStore {
    */
   hasPermission(permission: string): boolean {
     if (!this.isLoggedIn || !this.currentAccount) return false;
-    
+
     const role = this.currentAccount.role;
     if (role === 'administrator') return true;
-    
+
     // If permission specifically asks for administrator, deny non-admins
     if (permission === 'administrator') return false;
-    
+
     // For agents, check specific permissions if using custom roles
     // If not using custom roles, agents have basic permissions
     if (role === 'agent') {
       // Logic for standard agent vs custom role would go here
       // For now, assuming standard agent has access to basic features
-      return true; 
+      return true;
     }
-    
+
     return false;
   }
 
@@ -85,42 +92,46 @@ class AuthStore {
   isFeatureEnabled(featureFlag: string): boolean {
     // Check account specific features first
     const account = this.currentAccount;
-    if (account && account.features && account.features[featureFlag] !== undefined) {
+    if (
+      account &&
+      account.features &&
+      account.features[featureFlag] !== undefined
+    ) {
       return account.features[featureFlag];
     }
-    
+
     // Fallback to global config
     return globalConfig.isFeatureEnabled(featureFlag);
   }
-  
+
   /**
    * Get current user availability
    */
   get currentAvailability() {
     return this.currentAccount?.availability || 'offline';
   }
-  
+
   /**
    * Get current user auto-offline setting
    */
   get currentAutoOffline() {
     return this.currentAccount?.autoOffline || false;
   }
-  
+
   /**
    * Get current user role
    */
   get currentRole() {
     return this.currentAccount?.role || null;
   }
-  
+
   /**
    * Get current user custom role ID
    */
   get currentCustomRoleId() {
     return this.currentAccount?.customRoleId || null;
   }
-  
+
   /**
    * Check validity of current session
    */
@@ -129,22 +140,31 @@ class AuthStore {
       const user = await authAPI.validityCheck();
       this.setCurrentUser(user);
       this.error = null;
-    } catch (err: any) {
-      if (err?.response?.status === 401) {
+    } catch (err: unknown) {
+      const status =
+        typeof err === 'object' &&
+        err !== null &&
+        'response' in err &&
+        typeof (err as { response?: { status?: unknown } }).response?.status ===
+          'number'
+          ? (err as { response?: { status?: number } }).response?.status
+          : undefined;
+
+      if (status === 401) {
         this.clearUser();
       }
-      this.error = err.message || 'Failed to validate session';
+      this.error = this.getErrorMessage(err) || 'Failed to validate session';
       throw err;
     }
   }
-  
+
   /**
    * Validate current session (alias for validityCheck for compatibility)
    */
   async validateSession() {
     return this.validityCheck();
   }
-  
+
   /**
    * Initialize user session
    */
@@ -159,7 +179,7 @@ class AuthStore {
       this.isFetching = false;
     }
   }
-  
+
   /**
    * Logout current user
    */
@@ -171,16 +191,16 @@ class AuthStore {
       console.error('Logout error:', err);
     } finally {
       this.clearUser();
-      
+
       // Clear all localStorage
       clearStorage('current_user');
       clearStorage('auth_token');
-      
+
       // Redirect to login
-      goto('/login');
+      goto(resolve('/login'));
     }
   }
-  
+
   /**
    * Update user profile
    */
@@ -189,12 +209,12 @@ class AuthStore {
       const user = await authAPI.updateProfile(params);
       this.setCurrentUser(user);
       this.error = null;
-    } catch (err: any) {
-      this.error = err.message || 'Failed to update profile';
+    } catch (err: unknown) {
+      this.error = this.getErrorMessage(err) || 'Failed to update profile';
       throw err;
     }
   }
-  
+
   /**
    * Update user password
    */
@@ -203,12 +223,12 @@ class AuthStore {
       const user = await authAPI.updatePassword(params);
       this.setCurrentUser(user);
       this.error = null;
-    } catch (err: any) {
-      this.error = err.message || 'Failed to update password';
+    } catch (err: unknown) {
+      this.error = this.getErrorMessage(err) || 'Failed to update password';
       throw err;
     }
   }
-  
+
   /**
    * Delete user avatar
    */
@@ -222,21 +242,21 @@ class AuthStore {
       console.error('Delete avatar error:', err);
     }
   }
-  
+
   /**
    * Update UI settings
    */
-  async updateUISettings(uiSettings: Record<string, any>) {
+  async updateUISettings(uiSettings: Record<string, unknown>) {
     // Optimistically update UI settings
     this.currentUser = {
       ...this.currentUser,
       uiSettings: {
         ...this.currentUser.uiSettings,
-        ...uiSettings
-      }
+        ...uiSettings,
+      },
     };
     this.persistUser();
-    
+
     try {
       // Don't update on server if impersonating
       const isImpersonating = loadFromStorage<boolean>('impersonating');
@@ -250,65 +270,65 @@ class AuthStore {
       console.error('Update UI settings error:', err);
     }
   }
-  
+
   /**
    * Update availability status
    */
   async updateAvailability(params: AvailabilityUpdateParams) {
     const previousAvailability = this.currentAvailability;
-    
+
     // Optimistically update availability
     this.setAvailability(params.availability);
-    
+
     try {
       const user = await authAPI.updateAvailability(params);
       this.setCurrentUser(user);
       this.error = null;
-      
+
       // TODO: Dispatch to agents store to update presence
       // dispatch('agents/updateSingleAgentPresence', {
       //   id: user.id,
       //   availabilityStatus: params.availability
       // });
-    } catch (err: any) {
+    } catch (err: unknown) {
       // Revert on error
       this.setAvailability(previousAvailability);
-      this.error = err.message || 'Failed to update availability';
+      this.error = this.getErrorMessage(err) || 'Failed to update availability';
       throw err;
     }
   }
-  
+
   /**
    * Update auto-offline setting
    */
   async updateAutoOffline(accountId: number, autoOffline: boolean) {
     const previousAutoOffline = this.currentAutoOffline;
-    
+
     // Optimistically update
     this.setAutoOffline(autoOffline);
-    
+
     try {
       const user = await authAPI.updateAutoOffline(accountId, autoOffline);
       this.setCurrentUser(user);
       this.error = null;
-    } catch (err: any) {
+    } catch (err: unknown) {
       // Revert on error
       this.setAutoOffline(previousAutoOffline);
-      this.error = err.message || 'Failed to update auto-offline';
+      this.error = this.getErrorMessage(err) || 'Failed to update auto-offline';
       throw err;
     }
   }
-  
+
   /**
    * Set availability from external source (WebSocket)
    */
   setCurrentUserAvailability(data: Record<number, string>) {
     const userId = this.currentUser.id;
     if (data[userId]) {
-      this.setAvailability(data[userId] as any);
+      this.setAvailability(data[userId] as "online" | "offline" | "busy");
     }
   }
-  
+
   /**
    * Set active account
    */
@@ -321,7 +341,7 @@ class AuthStore {
       console.error('Set active account error:', err);
     }
   }
-  
+
   /**
    * Reset access token
    */
@@ -331,12 +351,12 @@ class AuthStore {
       this.setCurrentUser(user);
       this.error = null;
       return true;
-    } catch (err) {
+    } catch {
       this.error = 'Failed to reset access token';
       return false;
     }
   }
-  
+
   /**
    * Resend confirmation email
    */
@@ -355,31 +375,34 @@ class AuthStore {
    */
   async updateAccount(params: accountsAPI.UpdateAccountParams) {
     if (!this.currentAccountId) return;
-    
+
     try {
-      const updatedAccount = await accountsAPI.update(this.currentAccountId, params);
-      
+      const updatedAccount = await accountsAPI.update(
+        this.currentAccountId,
+        params
+      );
+
       // Update the account in the accounts list
       const accounts = this.currentUser.accounts.map(account => {
         if (account.id === this.currentAccountId) {
           return {
             ...account,
-            ...updatedAccount
+            ...updatedAccount,
           };
         }
         return account;
       });
-      
+
       this.currentUser = {
         ...this.currentUser,
-        accounts
+        accounts,
       };
-      
+
       this.persistUser();
       this.error = null;
       return updatedAccount;
-    } catch (err: any) {
-      this.error = err.message || 'Failed to update account';
+    } catch (err: unknown) {
+      this.error = this.getErrorMessage(err) || 'Failed to update account';
       throw err;
     }
   }
@@ -393,14 +416,43 @@ class AuthStore {
       await accountsAPI.toggleDeletion(this.currentAccountId, actionType);
       // Refresh user/account data to reflect changes
       await this.validityCheck();
-    } catch (err: any) {
-      this.error = err.message || 'Failed to toggle account deletion';
+    } catch (err: unknown) {
+      this.error = this.getErrorMessage(err) || 'Failed to toggle account deletion';
       throw err;
     }
   }
-  
+
+  /**
+   * Apply login payload to store and persistence layers.
+   */
+  setAuthenticatedUser(user: CurrentUser, token?: string) {
+    if (token) {
+      saveToStorage('auth_token', token);
+
+      if (typeof localStorage !== 'undefined') {
+        localStorage.setItem('auth_token', token);
+      }
+    }
+
+    this.setCurrentUser(user);
+
+    if (typeof localStorage !== 'undefined') {
+      localStorage.setItem('current_user', JSON.stringify(user));
+    }
+
+    this.error = null;
+  }
+
+  private getErrorMessage(error: unknown): string {
+    if (error instanceof Error) {
+      return error.message;
+    }
+
+    return '';
+  }
+
   // Private helper methods
-  
+
   /**
    * Set current user and persist
    */
@@ -408,7 +460,7 @@ class AuthStore {
     this.currentUser = user;
     this.persistUser();
   }
-  
+
   /**
    * Clear current user
    */
@@ -416,30 +468,30 @@ class AuthStore {
     this.currentUser = initialUser;
     clearStorage('current_user');
   }
-  
+
   /**
    * Set availability for current account
    */
-  private setAvailability(availability: string) {
+  private setAvailability(availability: "online" | "offline" | "busy") {
     const accountId = this.currentUser.accountId;
     const accounts = this.currentUser.accounts.map(account => {
       if (account.id === accountId) {
         return {
           ...account,
-          availability: availability as any,
-          availabilityStatus: availability as any
+          availability,
+          availabilityStatus: availability,
         };
       }
       return account;
     });
-    
+
     this.currentUser = {
       ...this.currentUser,
-      accounts
+      accounts,
     };
     this.persistUser();
   }
-  
+
   /**
    * Set auto-offline for current account
    */
@@ -451,14 +503,14 @@ class AuthStore {
       }
       return account;
     });
-    
+
     this.currentUser = {
       ...this.currentUser,
-      accounts
+      accounts,
     };
     this.persistUser();
   }
-  
+
   /**
    * Persist user to localStorage
    */

--- a/laravel-svelte-port/svelte-ui/src/lib/stores/reports.svelte.ts
+++ b/laravel-svelte-port/svelte-ui/src/lib/stores/reports.svelte.ts
@@ -221,7 +221,7 @@ class ReportsStore {
         params
       );
       this.state.overview.accountConversationMetric =
-        response.data as LiveAccountMetric;
+        response as LiveAccountMetric;
       console.log(
         '✅ Account conversation metrics fetched:',
         this.state.overview.accountConversationMetric
@@ -249,8 +249,11 @@ class ReportsStore {
       const response = await reportsApi.getLiveGroupedConversations(accountId, {
         groupBy: 'assignee_id',
       });
-      this.state.overview.agentConversationMetric =
-        response.data as LiveAgentMetric[];
+      this.state.overview.agentConversationMetric = response.map(metric => ({
+        assigneeId: metric.assignee_id || 0,
+        open: metric.open,
+        unattended: metric.unattended,
+      }));
       console.log(
         '✅ Agent conversation metrics fetched:',
         this.state.overview.agentConversationMetric
@@ -278,8 +281,11 @@ class ReportsStore {
       const response = await reportsApi.getLiveGroupedConversations(accountId, {
         groupBy: 'team_id',
       });
-      this.state.overview.teamConversationMetric =
-        response.data as LiveTeamMetric[];
+      this.state.overview.teamConversationMetric = response.map(metric => ({
+        teamId: metric.team_id || 0,
+        open: metric.open,
+        unattended: metric.unattended,
+      }));
       console.log(
         '✅ Team conversation metrics fetched:',
         this.state.overview.teamConversationMetric
@@ -411,7 +417,8 @@ class ReportsStore {
         accountId,
         mergedFilters
       );
-      this.state.conversationMetrics = response.data as ConversationMetrics;
+      this.state.conversationMetrics = ((response as { data?: unknown }).data ??
+        response) as ConversationMetrics;
     } catch (error) {
       this.state.error =
         error instanceof Error ? error.message : 'Failed to fetch reports';
@@ -645,7 +652,8 @@ class ReportsStore {
     try {
       console.log('🔄 Fetching account summary with params:', params);
       const response = await reportsApi.getAccountSummary(accountId, params);
-      this.state.conversationMetrics = response.data as ConversationMetrics;
+      this.state.conversationMetrics = ((response as { data?: unknown }).data ??
+        response) as ConversationMetrics;
       console.log('✅ Account summary fetched');
     } catch (error) {
       this.state.error =
@@ -683,7 +691,8 @@ class ReportsStore {
 
       // Store the report data - in Vue this would update a specific metric
       // For now, we'll update the main metrics
-      this.state.conversationMetrics = response.data as ConversationMetrics;
+      this.state.conversationMetrics = ((response as { data?: unknown }).data ??
+        response) as ConversationMetrics;
       console.log('✅ Account report fetched for metric:', params.metric);
     } catch (error) {
       this.state.error =
@@ -717,7 +726,8 @@ class ReportsStore {
     try {
       console.log('🔄 Fetching bot summary with params:', params);
       const response = await reportsApi.getBotSummary(accountId, params);
-      this.state.conversationMetrics = response.data as ConversationMetrics;
+      this.state.conversationMetrics = ((response as { data?: unknown }).data ??
+        response) as ConversationMetrics;
       console.log('✅ Bot summary fetched');
     } catch (error) {
       this.state.error =

--- a/laravel-svelte-port/svelte-ui/src/routes/app/login/+page.svelte
+++ b/laravel-svelte-port/svelte-ui/src/routes/app/login/+page.svelte
@@ -3,69 +3,76 @@
    * Login Page
    * User authentication page
    */
-  
+
   import { goto } from '$app/navigation';
+  import { resolve } from '$app/paths';
   import { login } from '$lib/api/auth';
+  import { authStore } from '$lib/stores/auth.svelte';
   import { Button } from '$lib/components/ui/button';
   import { Input } from '$lib/components/ui/input';
   import { Label } from '$lib/components/ui/label';
   import { toast } from 'svelte-sonner';
-  
+
   let email = $state('mdriaz@alpha.net.bd');
   let password = $state('12345678');
   let error = $state('');
   let loading = $state(false);
-  
+
+  function getErrorMessage(err: unknown): string {
+    if (typeof err === 'object' && err !== null) {
+      const knownError = err as {
+        response?: { data?: { errors?: Record<string, string[]>; message?: string } };
+        message?: string;
+      };
+
+      if (knownError.response?.data?.errors) {
+        return Object.values(knownError.response.data.errors).flat().join(', ');
+      }
+
+      if (knownError.response?.data?.message) {
+        return knownError.response.data.message;
+      }
+
+      if (knownError.message) {
+        return knownError.message;
+      }
+    }
+
+    return 'Login failed. Please check your credentials and try again.';
+  }
+
   async function handleSubmit(e: Event) {
     e.preventDefault();
     error = '';
     loading = true;
-    
+
     try {
       const response = await login({ email, password });
-      
-      // Store token and user data
-      if (response.token) {
-        localStorage.setItem('auth_token', response.token);
-      }
-      
+
+      // Store token and user data in auth store/local persistence
       if (response.user) {
-        localStorage.setItem('current_user', JSON.stringify(response.user));
-        
+        authStore.setAuthenticatedUser(response.user, response.token);
+
         // Redirect based on user type
         if (response.user.type === 'SuperAdmin') {
-          // Super admin - redirect to super admin dashboard
           toast.success('Logged in successfully!');
-          await goto('/app/super_admin/dashboard');
+          await goto(resolve('/app/super_admin/dashboard'));
           return;
         }
-        
+
         // Regular user - redirect to their account's conversations page
         if (response.user.accounts && response.user.accounts.length > 0) {
           const firstAccount = response.user.accounts[0];
           toast.success('Logged in successfully!');
-          await goto(`/app/accounts/${firstAccount.id}/conversations`);
+          await goto(resolve(`/app/accounts/${firstAccount.id}/conversations`));
           return;
         }
       }
-      
-      // Show success message
+
       toast.success('Logged in successfully!');
-      
-      // Fallback: redirect to app root (should not happen if user has accounts)
-      await goto('/app');
-    } catch (err: any) {
-      if (err.response?.data?.errors) {
-        // Laravel validation errors
-        const errors = err.response.data.errors;
-        error = Object.values(errors).flat().join(', ');
-      } else if (err.response?.data?.message) {
-        error = err.response.data.message;
-      } else if (err.message) {
-        error = err.message;
-      } else {
-        error = 'Login failed. Please check your credentials and try again.';
-      }
+      await goto(resolve('/app'));
+    } catch (err: unknown) {
+      error = getErrorMessage(err);
     } finally {
       loading = false;
     }
@@ -79,7 +86,7 @@
       Enter your credentials to access your account
     </p>
   </div>
-  
+
   <form onsubmit={handleSubmit} class="space-y-4">
     <div class="space-y-2">
       <Label for="email">Email</Label>
@@ -92,7 +99,7 @@
         disabled={loading}
       />
     </div>
-    
+
     <div class="space-y-2">
       <Label for="password">Password</Label>
       <Input
@@ -104,28 +111,26 @@
         disabled={loading}
       />
     </div>
-    
+
     {#if error}
       <div class="rounded-md bg-destructive/10 p-3 text-sm text-destructive">
         {error}
       </div>
     {/if}
-    
+
     <Button type="submit" class="w-full" disabled={loading}>
       {loading ? 'Signing in...' : 'Sign in'}
     </Button>
   </form>
-  
+
   <div class="text-center text-sm">
-    <a href="/auth/forgot-password" class="text-primary hover:underline">
-      Forgot your password?
+    <a href={resolve('/login')} class="text-primary hover:underline">
+      Need help signing in?
     </a>
   </div>
-  
+
   <div class="text-center text-sm text-muted-foreground">
-    Don't have an account?{' '}
-    <a href="/app/signup" class="text-primary hover:underline">
-      Sign up
-    </a>
+    Don't have an account?
+    <a href={resolve('/app/signup')} class="text-primary hover:underline">Sign up</a>
   </div>
 </div>

--- a/laravel-svelte-port/svelte-ui/src/routes/app/login/+page.svelte
+++ b/laravel-svelte-port/svelte-ui/src/routes/app/login/+page.svelte
@@ -14,10 +14,20 @@
   import { Label } from '$lib/components/ui/label';
   import { toast } from 'svelte-sonner';
 
-  let email = $state('');
-  let password = $state('');
+  const SEEDED_LOGIN = {
+    email: 'michael_scott@paperlayer.test',
+    password: 'Password1!.',
+  };
+
+  let email = $state(SEEDED_LOGIN.email);
+  let password = $state(SEEDED_LOGIN.password);
   let error = $state('');
   let loading = $state(false);
+
+  function useSeededCredentials() {
+    email = SEEDED_LOGIN.email;
+    password = SEEDED_LOGIN.password;
+  }
 
   async function handleSubmit(e: Event) {
     e.preventDefault();
@@ -61,7 +71,7 @@
   <div class="space-y-2 text-center">
     <h2 class="text-2xl font-semibold tracking-tight">Sign in</h2>
     <p class="text-sm text-muted-foreground">
-      Enter your credentials to access your account
+      Enter your credentials to access your account. Seeded login is prefilled for instant testing.
     </p>
   </div>
 
@@ -98,6 +108,16 @@
 
     <Button type="submit" class="w-full" disabled={loading}>
       {loading ? 'Signing in...' : 'Sign in'}
+    </Button>
+
+    <Button
+      type="button"
+      variant="outline"
+      class="w-full"
+      disabled={loading}
+      onclick={useSeededCredentials}
+    >
+      Use seeded credentials
     </Button>
   </form>
 

--- a/laravel-svelte-port/svelte-ui/src/routes/app/login/+page.svelte
+++ b/laravel-svelte-port/svelte-ui/src/routes/app/login/+page.svelte
@@ -7,39 +7,17 @@
   import { goto } from '$app/navigation';
   import { resolve } from '$app/paths';
   import { login } from '$lib/api/auth';
+  import { getErrorMessage } from '$lib/api/errors';
   import { authStore } from '$lib/stores/auth.svelte';
   import { Button } from '$lib/components/ui/button';
   import { Input } from '$lib/components/ui/input';
   import { Label } from '$lib/components/ui/label';
   import { toast } from 'svelte-sonner';
 
-  let email = $state('mdriaz@alpha.net.bd');
-  let password = $state('12345678');
+  let email = $state('');
+  let password = $state('');
   let error = $state('');
   let loading = $state(false);
-
-  function getErrorMessage(err: unknown): string {
-    if (typeof err === 'object' && err !== null) {
-      const knownError = err as {
-        response?: { data?: { errors?: Record<string, string[]>; message?: string } };
-        message?: string;
-      };
-
-      if (knownError.response?.data?.errors) {
-        return Object.values(knownError.response.data.errors).flat().join(', ');
-      }
-
-      if (knownError.response?.data?.message) {
-        return knownError.response.data.message;
-      }
-
-      if (knownError.message) {
-        return knownError.message;
-      }
-    }
-
-    return 'Login failed. Please check your credentials and try again.';
-  }
 
   async function handleSubmit(e: Event) {
     e.preventDefault();
@@ -124,8 +102,8 @@
   </form>
 
   <div class="text-center text-sm">
-    <a href={resolve('/login')} class="text-primary hover:underline">
-      Need help signing in?
+    <a href={resolve('/auth/forgot-password')} class="text-primary hover:underline">
+      Forgot your password?
     </a>
   </div>
 

--- a/laravel-svelte-port/svelte-ui/src/routes/auth/forgot-password/+page.svelte
+++ b/laravel-svelte-port/svelte-ui/src/routes/auth/forgot-password/+page.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+  import { resolve } from '$app/paths';
+</script>
+
+<div class="mx-auto max-w-md space-y-3 text-center">
+  <h1 class="text-2xl font-semibold tracking-tight">Need help signing in?</h1>
+  <p class="text-sm text-muted-foreground">
+    Password reset is currently managed by your workspace administrator. Please contact your
+    administrator to regain access.
+  </p>
+
+  <a class="text-sm text-primary hover:underline" href={resolve('/app/login')}>Back to sign in</a>
+</div>

--- a/laravel-svelte-port/svelte-ui/vite.config.ts
+++ b/laravel-svelte-port/svelte-ui/vite.config.ts
@@ -6,14 +6,24 @@ export default defineConfig({
   plugins: [tailwindcss(), sveltekit()],
   server: {
     port: 5173,
-    strictPort: false
+    strictPort: false,
+    proxy: {
+      '/api': {
+        target: 'http://127.0.0.1:8000',
+        changeOrigin: true,
+      },
+      '/auth': {
+        target: 'http://127.0.0.1:8000',
+        changeOrigin: true,
+      },
+    },
   },
   resolve: {
     alias: {
-      $lib: "./src/lib",
+      $lib: './src/lib',
     },
   },
   preview: {
-    port: 4173
-  }
+    port: 4173,
+  },
 });


### PR DESCRIPTION
### Motivation
- The existing Laravel account seed data was scattered, duplicated and inconsistent with the Rails seeds; the goal is to provide a clean, professional, Rails-parity demo dataset and make seeding deterministic and robust.
- Seeding needs predictable team membership mapping and safer cleanup ordering to avoid FK issues and accidental deletion of shared user records.

### Description
- Reworked the seed dataset in `app/DataTransferObjects/SeedData.php` to a structured, professional default set (company, teams, `customRoles`, `labels`, `users`, `contacts`/conversations) modeled after `lib/seeders/seed_data.yml` for Rails parity.
- Refactored `app/Services/Seeding/AccountSeederService.php` to improve robustness by introducing a `teamLookup` populated during `seedTeams`, deterministic team name normalization via `normalizeTeamName()`, and using the lookup in `addUserToTeams` instead of loose `LIKE` queries.
- Improved cleanup ordering and safety: deletion order was adjusted to preserve referential integrity, labels/labelings ordering fixed, and seeded test users (`%@paperlayer.test`) are deleted only when not referenced in `account_users` (preventing accidental removal of users still in use).
- Cosmetic and imports cleanup, formatting applied with `pint`, and small code-style tidyups (whitespace/consistency changes).

### Testing
- Installed PHP deps with `composer install --no-interaction --prefer-dist` and ran `./vendor/bin/pint` to format updated files; both succeeded.
- Performed syntax check with `php -l` on `SeedData.php` and `AccountSeederService.php`; both returned "No syntax errors detected".
- Ran full database flow by creating an sqlite file and running `php artisan migrate:fresh --seed --force`, which completed migrations and seeders successfully (seeders run: `RolesAndPermissionsSeeder`, `InstallationConfigSeeder`, `OnboardingFlagSeeder`, `DemoReportsSeeder`).
- Verified seeded data via sqlite queries: `users` with `@paperlayer.test` = 14, `teams` = 4, `custom_roles` = 6, `contacts` = 9, `conversations` = 9, `inboxes` distinct channel types = 10, and labels list populated as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_698ca4d311bc832a9557033695051600)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CSV export for conversation summaries and richer report exports with extended metrics (response times, resolutions, message counts)

* **Improvements**
  * Centralized report parameter/timezone handling and more consistent API response shapes
  * Safer and unified data handling for live/historical report retrieval
  * Lightweight inline report chart rendering and sidebar route fix for Reports → Conversation
  * Enhanced auth persistence, standardized error messages, and seeded login helper

* **Documentation**
  * Added screenshot-based verification guide for the Reports UI

* **Chores**
  * Updated seeded demo data and dev server proxy/config tweaks
<!-- end of auto-generated comment: release notes by coderabbit.ai -->