### PR TITLE
Align account pages with backend API contracts

### DIFF
--- a/laravel-svelte-port/svelte-ui/src/lib/api/accounts.ts
+++ b/laravel-svelte-port/svelte-ui/src/lib/api/accounts.ts
@@ -17,20 +17,43 @@ export interface UpdateAccountParams {
 /**
  * Update account details
  */
-export async function update(accountId: number, params: UpdateAccountParams): Promise<UserAccount> {
+export async function update(
+  accountId: number,
+  params: UpdateAccountParams
+): Promise<UserAccount> {
   // The client automatically converts camelCase params to snake_case for the request
-  const response = await api.patch(`api/v1/accounts/${accountId}`, {
-    json: params
-  }).json<{ data: UserAccount }>();
-  
+  const response = await api
+    .patch(`api/v1/accounts/${accountId}`, {
+      json: params,
+    })
+    .json<{ data: UserAccount }>();
+
   return response.data;
 }
 
 /**
  * Toggle account deletion
  */
-export async function toggleDeletion(accountId: number, actionType: 'delete' | 'undelete'): Promise<void> {
+export async function toggleDeletion(
+  accountId: number,
+  actionType: 'delete' | 'undelete'
+): Promise<void> {
   await api.post(`enterprise/api/v1/accounts/${accountId}/toggle_deletion`, {
-    json: { action_type: actionType }
+    json: { action_type: actionType },
   });
+}
+
+export interface AccountDetails extends UserAccount {
+  limits?: Record<string, unknown>;
+  status?: string;
+}
+
+/**
+ * Get account details
+ */
+export async function show(accountId: number): Promise<AccountDetails> {
+  const response = await api
+    .get(`api/v1/accounts/${accountId}`)
+    .json<{ data: AccountDetails }>();
+  return response.data;
 }

--- a/laravel-svelte-port/svelte-ui/src/lib/api/billing.ts
+++ b/laravel-svelte-port/svelte-ui/src/lib/api/billing.ts
@@ -23,7 +23,11 @@ export async function getCurrentPlan(accountId: number): Promise<BillingPlan> {
     name: 'Workspace Plan',
     amount: 0,
     billingCycle: 'monthly',
-    features: Object.keys(account.features || {}).slice(0, 5),
+    features: Object.keys(account.features || {})
+      .slice(0, 5)
+      .map(key =>
+        key.replace(/_/g, ' ').replace(/\b\w/g, char => char.toUpperCase())
+      ),
     status: account.status || 'active',
   };
 }

--- a/laravel-svelte-port/svelte-ui/src/lib/api/billing.ts
+++ b/laravel-svelte-port/svelte-ui/src/lib/api/billing.ts
@@ -1,0 +1,35 @@
+import { show } from './accounts';
+
+export interface BillingPlan {
+  name: string;
+  amount: number;
+  billingCycle: string;
+  features: string[];
+  status: string;
+}
+
+export interface BillingInvoice {
+  id: string;
+  date: string;
+  amount: number;
+  status: string;
+  downloadUrl?: string;
+}
+
+export async function getCurrentPlan(accountId: number): Promise<BillingPlan> {
+  const account = await show(accountId);
+
+  return {
+    name: 'Workspace Plan',
+    amount: 0,
+    billingCycle: 'monthly',
+    features: Object.keys(account.features || {}).slice(0, 5),
+    status: account.status || 'active',
+  };
+}
+
+export async function getInvoices(
+  _accountId: number
+): Promise<BillingInvoice[]> {
+  return [];
+}

--- a/laravel-svelte-port/svelte-ui/src/lib/api/cannedResponses.ts
+++ b/laravel-svelte-port/svelte-ui/src/lib/api/cannedResponses.ts
@@ -1,0 +1,48 @@
+import { api, toSearchParams } from './client';
+
+export interface CannedResponse {
+  id: number;
+  shortCode: string;
+  content: string;
+  accountId: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CannedResponseListParams {
+  page?: number;
+  perPage?: number;
+  search?: string;
+}
+
+interface CannedResponseListMeta {
+  currentPage: number;
+  lastPage: number;
+  perPage: number;
+  total: number;
+}
+
+export interface CannedResponseListResponse {
+  data: CannedResponse[];
+  meta: CannedResponseListMeta;
+}
+
+export async function getCannedResponses(
+  accountId: number,
+  params: CannedResponseListParams = {}
+): Promise<CannedResponseListResponse> {
+  return api
+    .get(`api/v1/accounts/${accountId}/canned_responses`, {
+      searchParams: toSearchParams(params),
+    })
+    .json<CannedResponseListResponse>();
+}
+
+export async function deleteCannedResponse(
+  accountId: number,
+  cannedResponseId: number
+): Promise<void> {
+  await api.delete(
+    `api/v1/accounts/${accountId}/canned_responses/${cannedResponseId}`
+  );
+}

--- a/laravel-svelte-port/svelte-ui/src/lib/api/integrations.ts
+++ b/laravel-svelte-port/svelte-ui/src/lib/api/integrations.ts
@@ -1,0 +1,36 @@
+import { api } from './client';
+
+export interface Integration {
+  id: string;
+  appId?: string;
+  name: string;
+  description?: string;
+  status: 'connected' | 'available';
+  logo?: string;
+}
+
+interface IntegrationApiResponse {
+  id: string;
+  appId?: string;
+  name: string;
+  description?: string;
+  enabled?: boolean;
+  logo?: string;
+}
+
+export async function getIntegrations(
+  accountId: number
+): Promise<Integration[]> {
+  const response = await api
+    .get(`api/v1/accounts/${accountId}/integrations`)
+    .json<{ data: IntegrationApiResponse[] }>();
+
+  return (response.data || []).map(integration => ({
+    id: integration.id,
+    appId: integration.appId,
+    name: integration.name,
+    description: integration.description,
+    logo: integration.logo,
+    status: integration.enabled ? 'connected' : 'available',
+  }));
+}

--- a/laravel-svelte-port/svelte-ui/src/lib/api/search.ts
+++ b/laravel-svelte-port/svelte-ui/src/lib/api/search.ts
@@ -41,47 +41,53 @@ export interface SearchResponse {
  * Global search across all entities
  */
 export async function search(
+  accountId: number,
   query: string,
   filters: SearchFilters = {},
   page: number = 1
 ): Promise<SearchResponse> {
-  return api.get('api/v1/search', {
-    searchParams: toSearchParams({
-      q: query,
-      ...filters,
-      page
+  return api
+    .get(`api/v1/accounts/${accountId}/search`, {
+      searchParams: toSearchParams({
+        q: query,
+        ...filters,
+        page,
+      }),
     })
-  }).json();
+    .json();
 }
 
 /**
  * Search conversations specifically
  */
 export async function searchConversations(
+  accountId: number,
   query: string,
   filters: Omit<SearchFilters, 'type'> = {},
   page: number = 1
 ): Promise<SearchResponse> {
-  return search(query, { ...filters, type: 'conversation' }, page);
+  return search(accountId, query, { ...filters, type: 'conversation' }, page);
 }
 
 /**
  * Search contacts specifically
  */
 export async function searchContacts(
+  accountId: number,
   query: string,
   page: number = 1
 ): Promise<SearchResponse> {
-  return search(query, { type: 'contact' }, page);
+  return search(accountId, query, { type: 'contact' }, page);
 }
 
 /**
  * Search messages specifically
  */
 export async function searchMessages(
+  accountId: number,
   query: string,
   filters: Omit<SearchFilters, 'type'> = {},
   page: number = 1
 ): Promise<SearchResponse> {
-  return search(query, { ...filters, type: 'message' }, page);
+  return search(accountId, query, { ...filters, type: 'message' }, page);
 }

--- a/laravel-svelte-port/svelte-ui/src/lib/api/search.ts
+++ b/laravel-svelte-port/svelte-ui/src/lib/api/search.ts
@@ -88,10 +88,24 @@ function normalizeSearchResponse(
   perPage: number
 ): SearchResponse {
   if (Array.isArray(response.results)) {
+    const normalizedResults = response.results.map(item => {
+      const resultType =
+        item.type === 'conversation' ||
+        item.type === 'contact' ||
+        item.type === 'message'
+          ? item.type
+          : 'conversation';
+
+      return toSearchResult(
+        resultType,
+        item as unknown as Record<string, unknown>
+      );
+    });
+
     return {
-      results: response.results,
+      results: normalizedResults,
       meta: {
-        total: response.meta?.total ?? response.results.length,
+        total: response.meta?.total ?? normalizedResults.length,
         page,
         perPage,
       },

--- a/laravel-svelte-port/svelte-ui/src/lib/api/search.ts
+++ b/laravel-svelte-port/svelte-ui/src/lib/api/search.ts
@@ -50,10 +50,10 @@ function toSearchResult(
   type: SearchResult['type'],
   item: Record<string, unknown>
 ): SearchResult {
-  const id = Number(item.id ?? 0);
-  const conversationId = Number(
-    item.conversationId ?? item.conversation_id ?? item.id ?? 0
-  );
+  const id = Number(item.id ?? 0) || 0;
+  const conversationId =
+    Number(item.conversationId ?? item.conversation_id ?? item.id ?? 0) || 0;
+  const contactId = Number(item.contactId ?? item.contact_id ?? 0) || 0;
 
   return {
     id,
@@ -75,10 +75,7 @@ function toSearchResult(
       (item.email as string | undefined),
     conversationId:
       type === 'contact' ? undefined : conversationId || undefined,
-    contactId:
-      type === 'contact'
-        ? id
-        : Number(item.contactId ?? item.contact_id ?? 0) || undefined,
+    contactId: type === 'contact' ? id : contactId || undefined,
     createdAt: String(
       item.createdAt ?? item.created_at ?? new Date().toISOString()
     ),

--- a/laravel-svelte-port/svelte-ui/src/lib/api/search.ts
+++ b/laravel-svelte-port/svelte-ui/src/lib/api/search.ts
@@ -3,7 +3,7 @@
  * Handles global search across conversations, contacts, and messages
  */
 
-import api, { toSearchParams } from './client';
+import { api, toSearchParams } from './client';
 
 export interface SearchResult {
   id: number;
@@ -37,6 +37,92 @@ export interface SearchResponse {
   };
 }
 
+interface AccountSearchResponse {
+  data?: Record<string, Record<string, unknown>[]>;
+  results?: SearchResult[];
+  meta?: {
+    total?: number;
+    totalTypes?: number;
+  };
+}
+
+function toSearchResult(
+  type: SearchResult['type'],
+  item: Record<string, unknown>
+): SearchResult {
+  const id = Number(item.id ?? 0);
+  const conversationId = Number(
+    item.conversationId ?? item.conversation_id ?? item.id ?? 0
+  );
+
+  return {
+    id,
+    type,
+    title:
+      String(
+        item.title ??
+          item.name ??
+          item.subject ??
+          item.displayId ??
+          item.display_id ??
+          item.content ??
+          item.id ??
+          ''
+      ) || `#${id}`,
+    description:
+      (item.description as string | undefined) ??
+      (item.content as string | undefined) ??
+      (item.email as string | undefined),
+    conversationId:
+      type === 'contact' ? undefined : conversationId || undefined,
+    contactId:
+      type === 'contact'
+        ? id
+        : Number(item.contactId ?? item.contact_id ?? 0) || undefined,
+    createdAt: String(
+      item.createdAt ?? item.created_at ?? new Date().toISOString()
+    ),
+  };
+}
+
+function normalizeSearchResponse(
+  response: AccountSearchResponse,
+  page: number,
+  perPage: number
+): SearchResponse {
+  if (Array.isArray(response.results)) {
+    return {
+      results: response.results,
+      meta: {
+        total: response.meta?.total ?? response.results.length,
+        page,
+        perPage,
+      },
+    };
+  }
+
+  const grouped = response.data ?? {};
+  const mapping: Array<{ key: string; type: SearchResult['type'] }> = [
+    { key: 'conversations', type: 'conversation' },
+    { key: 'contacts', type: 'contact' },
+    { key: 'messages', type: 'message' },
+  ];
+
+  const results = mapping.flatMap(({ key, type }) => {
+    const items = (grouped[key] ?? []) as Record<string, unknown>[];
+    return items.map(item => toSearchResult(type, item));
+  });
+
+  return {
+    results,
+    meta: {
+      total: response.meta?.total ?? results.length,
+      page,
+      perPage,
+    },
+  };
+}
+
 /**
  * Global search across all entities
  */
@@ -46,15 +132,19 @@ export async function search(
   filters: SearchFilters = {},
   page: number = 1
 ): Promise<SearchResponse> {
-  return api
+  const perPage = 15;
+  const response = await api
     .get(`api/v1/accounts/${accountId}/search`, {
       searchParams: toSearchParams({
         q: query,
         ...filters,
         page,
+        perPage,
       }),
     })
-    .json();
+    .json<AccountSearchResponse>();
+
+  return normalizeSearchResponse(response, page, perPage);
 }
 
 /**

--- a/laravel-svelte-port/svelte-ui/src/lib/components/reports/shared/ReportChart.svelte
+++ b/laravel-svelte-port/svelte-ui/src/lib/components/reports/shared/ReportChart.svelte
@@ -5,13 +5,19 @@
   interface Props {
     title: string;
     metricKey: string;
+    groupBy?: string | null;
     isTime?: boolean;
   }
 
-  let { title, metricKey, isTime = false }: Props = $props();
+  let { title, metricKey, groupBy = null, isTime = false }: Props = $props();
 
-  const rawChartData = $derived(reportsStore.getChartData(metricKey));
-  const isLoading = $derived(reportsStore.getUIFlag(`isFetching_${metricKey}`));
+  const chartMetricKey = $derived(
+    groupBy ? `${metricKey}_${groupBy}` : metricKey
+  );
+  const rawChartData = $derived(reportsStore.getChartData(chartMetricKey));
+  const isLoading = $derived(
+    reportsStore.getUIFlag(`isFetching_${chartMetricKey}`)
+  );
 
   const chartData = $derived.by<{ data: number[]; labels: string[] }>(() => {
     if (
@@ -21,7 +27,9 @@
     ) {
       return {
         data: rawChartData.data.map((point: unknown) => Number(point) || 0),
-        labels: rawChartData.labels.map((label: unknown) => String(label ?? '')),
+        labels: rawChartData.labels.map((label: unknown) =>
+          String(label ?? '')
+        ),
       };
     }
 
@@ -70,15 +78,22 @@
   {#if isLoading}
     <div class="h-[300px] animate-pulse bg-muted rounded"></div>
   {:else if points.length > 0}
-    <div class="h-[300px] flex items-end gap-1 rounded bg-muted/20 p-3 overflow-x-auto">
+    <div
+      class="h-[300px] flex items-end gap-1 rounded bg-muted/20 p-3 overflow-x-auto"
+    >
       {#each points as point, index (index)}
-        <div class="flex flex-col items-center min-w-[18px]" title={formatValue(point)}>
+        <div
+          class="flex flex-col items-center min-w-[18px]"
+          title={formatValue(point)}
+        >
           <div
             class="w-4 rounded-t bg-primary/70 hover:bg-primary transition-colors"
             style={`height: ${Math.max((point / maxValue) * 220, 2)}px`}
           ></div>
           {#if labels[index]}
-            <span class="mt-1 text-[10px] text-muted-foreground truncate max-w-[18px]">
+            <span
+              class="mt-1 text-[10px] text-muted-foreground truncate max-w-[18px]"
+            >
               {labels[index]}
             </span>
           {/if}
@@ -86,7 +101,9 @@
       {/each}
     </div>
   {:else}
-    <div class="h-[300px] flex items-center justify-center text-muted-foreground">
+    <div
+      class="h-[300px] flex items-center justify-center text-muted-foreground"
+    >
       No data available
     </div>
   {/if}

--- a/laravel-svelte-port/svelte-ui/src/lib/stores/billing.svelte.ts
+++ b/laravel-svelte-port/svelte-ui/src/lib/stores/billing.svelte.ts
@@ -28,8 +28,11 @@ class BillingStore {
 
       this.plan = plan;
       this.invoices = invoices;
-    } catch (err: any) {
-      this.error = err.message || 'Failed to fetch billing information';
+    } catch (err: unknown) {
+      this.error =
+        err instanceof Error
+          ? err.message
+          : 'Failed to fetch billing information';
       this.plan = null;
       this.invoices = [];
     } finally {

--- a/laravel-svelte-port/svelte-ui/src/lib/stores/billing.svelte.ts
+++ b/laravel-svelte-port/svelte-ui/src/lib/stores/billing.svelte.ts
@@ -1,0 +1,41 @@
+import { page } from '$app/stores';
+import { get } from 'svelte/store';
+import * as billingApi from '$lib/api/billing';
+import type { BillingInvoice, BillingPlan } from '$lib/api/billing';
+
+class BillingStore {
+  plan = $state<BillingPlan | null>(null);
+  invoices = $state<BillingInvoice[]>([]);
+  isLoading = $state(false);
+  error = $state<string | null>(null);
+
+  get currentAccountId(): number {
+    const pageStore = get(page);
+    return parseInt(pageStore.params.accountId || '0', 10);
+  }
+
+  async fetch(): Promise<void> {
+    if (!this.currentAccountId) return;
+
+    this.isLoading = true;
+    this.error = null;
+
+    try {
+      const [plan, invoices] = await Promise.all([
+        billingApi.getCurrentPlan(this.currentAccountId),
+        billingApi.getInvoices(this.currentAccountId),
+      ]);
+
+      this.plan = plan;
+      this.invoices = invoices;
+    } catch (err: any) {
+      this.error = err.message || 'Failed to fetch billing information';
+      this.plan = null;
+      this.invoices = [];
+    } finally {
+      this.isLoading = false;
+    }
+  }
+}
+
+export const billingStore = new BillingStore();

--- a/laravel-svelte-port/svelte-ui/src/lib/stores/cannedResponses.svelte.ts
+++ b/laravel-svelte-port/svelte-ui/src/lib/stores/cannedResponses.svelte.ts
@@ -1,0 +1,68 @@
+import { page } from '$app/stores';
+import { get } from 'svelte/store';
+import * as cannedResponsesApi from '$lib/api/cannedResponses';
+import type {
+  CannedResponse,
+  CannedResponseListParams,
+} from '$lib/api/cannedResponses';
+
+class CannedResponsesStore {
+  items = $state<CannedResponse[]>([]);
+  isLoading = $state(false);
+  isDeleting = $state(false);
+  error = $state<string | null>(null);
+  currentPage = $state(1);
+  lastPage = $state(1);
+  perPage = $state(15);
+  total = $state(0);
+
+  get currentAccountId(): number {
+    const pageStore = get(page);
+    return parseInt(pageStore.params.accountId || '0', 10);
+  }
+
+  async fetch(params: CannedResponseListParams = {}): Promise<void> {
+    if (!this.currentAccountId) return;
+
+    this.isLoading = true;
+    this.error = null;
+
+    try {
+      const response = await cannedResponsesApi.getCannedResponses(
+        this.currentAccountId,
+        params
+      );
+      this.items = response.data || [];
+      this.currentPage = response.meta?.currentPage || params.page || 1;
+      this.lastPage = response.meta?.lastPage || 1;
+      this.perPage = response.meta?.perPage || 15;
+      this.total = response.meta?.total || 0;
+    } catch (err: any) {
+      this.error = err.message || 'Failed to fetch canned responses';
+      this.items = [];
+    } finally {
+      this.isLoading = false;
+    }
+  }
+
+  async delete(id: number): Promise<boolean> {
+    if (!this.currentAccountId) return false;
+
+    this.isDeleting = true;
+    this.error = null;
+
+    try {
+      await cannedResponsesApi.deleteCannedResponse(this.currentAccountId, id);
+      this.items = this.items.filter(item => item.id !== id);
+      this.total = Math.max(0, this.total - 1);
+      return true;
+    } catch (err: any) {
+      this.error = err.message || 'Failed to delete canned response';
+      return false;
+    } finally {
+      this.isDeleting = false;
+    }
+  }
+}
+
+export const cannedResponsesStore = new CannedResponsesStore();

--- a/laravel-svelte-port/svelte-ui/src/lib/stores/integrations.svelte.ts
+++ b/laravel-svelte-port/svelte-ui/src/lib/stores/integrations.svelte.ts
@@ -1,0 +1,39 @@
+import { page } from '$app/stores';
+import { get } from 'svelte/store';
+import * as integrationsApi from '$lib/api/integrations';
+import type { Integration } from '$lib/api/integrations';
+
+class IntegrationsStore {
+  integrations = $state<Integration[]>([]);
+  isLoading = $state(false);
+  error = $state<string | null>(null);
+
+  get currentAccountId(): number {
+    const pageStore = get(page);
+    return parseInt(pageStore.params.accountId || '0', 10);
+  }
+
+  get connectedCount(): number {
+    return this.integrations.filter(item => item.status === 'connected').length;
+  }
+
+  async fetch(): Promise<void> {
+    if (!this.currentAccountId) return;
+
+    this.isLoading = true;
+    this.error = null;
+
+    try {
+      this.integrations = await integrationsApi.getIntegrations(
+        this.currentAccountId
+      );
+    } catch (err: any) {
+      this.error = err.message || 'Failed to fetch integrations';
+      this.integrations = [];
+    } finally {
+      this.isLoading = false;
+    }
+  }
+}
+
+export const integrationsStore = new IntegrationsStore();

--- a/laravel-svelte-port/svelte-ui/src/lib/stores/search.svelte.ts
+++ b/laravel-svelte-port/svelte-ui/src/lib/stores/search.svelte.ts
@@ -22,9 +22,16 @@ interface SearchState {
 const MAX_HISTORY = 10;
 
 class SearchStore {
-  get currentAccountId(): number {
+  get currentAccountId(): number | undefined {
     const pageStore = get(page);
-    return parseInt(pageStore.params.accountId || '0', 10);
+    const accountIdParam = pageStore.params.accountId;
+
+    if (!accountIdParam) return undefined;
+
+    const parsedAccountId = Number.parseInt(accountIdParam, 10);
+    return Number.isFinite(parsedAccountId) && parsedAccountId > 0
+      ? parsedAccountId
+      : undefined;
   }
   private state = $state<SearchState>({
     query: '',
@@ -104,9 +111,21 @@ class SearchStore {
     this.state.error = null;
     this.state.currentPage = pageNumber;
 
+    const accountId = this.currentAccountId;
+
+    if (!accountId) {
+      this.state.error =
+        'Search is unavailable because the account context is missing. Please refresh this page from an account route.';
+      this.state.isSearching = false;
+      console.warn(
+        '[SearchStore] Aborting search request due to missing/invalid accountId'
+      );
+      return;
+    }
+
     try {
       const response = await searchApi.search(
-        this.currentAccountId,
+        accountId,
         query,
         filters,
         pageNumber

--- a/laravel-svelte-port/svelte-ui/src/lib/stores/search.svelte.ts
+++ b/laravel-svelte-port/svelte-ui/src/lib/stores/search.svelte.ts
@@ -1,3 +1,5 @@
+import { page } from '$app/stores';
+import { get } from 'svelte/store';
 /**
  * Search Store
  * Manages search state and history using Svelte 5 runes
@@ -20,6 +22,10 @@ interface SearchState {
 const MAX_HISTORY = 10;
 
 class SearchStore {
+  get currentAccountId(): number {
+    const pageStore = get(page);
+    return parseInt(pageStore.params.accountId || '0', 10);
+  }
   private state = $state<SearchState>({
     query: '',
     results: [],
@@ -28,7 +34,7 @@ class SearchStore {
     error: null,
     currentPage: 1,
     totalResults: 0,
-    history: this.loadHistory()
+    history: this.loadHistory(),
   });
 
   // Getters
@@ -62,33 +68,31 @@ class SearchStore {
 
   // Derived getters
   get conversationResults() {
-    return (
-      this.state.results.filter(r => r.type === 'conversation')
-    );
+    return this.state.results.filter(r => r.type === 'conversation');
   }
 
   get contactResults() {
-    return (
-      this.state.results.filter(r => r.type === 'contact')
-    );
+    return this.state.results.filter(r => r.type === 'contact');
   }
 
   get messageResults() {
-    return (
-      this.state.results.filter(r => r.type === 'message')
-    );
+    return this.state.results.filter(r => r.type === 'message');
   }
 
   get hasResults() {
-    return (this.state.results.length > 0);
+    return this.state.results.length > 0;
   }
 
   get hasQuery() {
-    return (this.state.query.trim().length > 0);
+    return this.state.query.trim().length > 0;
   }
 
   // Actions
-  async performSearch(query: string, filters: SearchFilters = {}, page: number = 1) {
+  async performSearch(
+    query: string,
+    filters: SearchFilters = {},
+    page: number = 1
+  ) {
     if (!query.trim()) {
       this.clearResults();
       return;
@@ -101,27 +105,36 @@ class SearchStore {
     this.state.currentPage = page;
 
     try {
-      const response = await searchApi.search(query, filters, page);
-      
+      const response = await searchApi.search(
+        this.currentAccountId,
+        query,
+        filters,
+        page
+      );
+
       if (page === 1) {
         this.state.results = response.results;
       } else {
         this.state.results = [...this.state.results, ...response.results];
       }
-      
+
       this.state.totalResults = response.meta.total;
-      
+
       // Add to history
       this.addToHistory(query);
     } catch (error) {
-      this.state.error = error instanceof Error ? error.message : 'Search failed';
+      this.state.error =
+        error instanceof Error ? error.message : 'Search failed';
       console.error('Search error:', error);
     } finally {
       this.state.isSearching = false;
     }
   }
 
-  async searchConversations(query: string, filters: Omit<SearchFilters, 'type'> = {}) {
+  async searchConversations(
+    query: string,
+    filters: Omit<SearchFilters, 'type'> = {}
+  ) {
     await this.performSearch(query, { ...filters, type: 'conversation' });
   }
 
@@ -129,13 +142,16 @@ class SearchStore {
     await this.performSearch(query, { type: 'contact' });
   }
 
-  async searchMessages(query: string, filters: Omit<SearchFilters, 'type'> = {}) {
+  async searchMessages(
+    query: string,
+    filters: Omit<SearchFilters, 'type'> = {}
+  ) {
     await this.performSearch(query, { ...filters, type: 'message' });
   }
 
   async loadMore() {
     if (this.state.isSearching || !this.state.query) return;
-    
+
     await this.performSearch(
       this.state.query,
       this.state.filters,
@@ -169,7 +185,7 @@ class SearchStore {
   // History management
   private loadHistory(): string[] {
     if (typeof localStorage === 'undefined') return [];
-    
+
     try {
       const saved = localStorage.getItem('search_history');
       return saved ? JSON.parse(saved) : [];
@@ -180,9 +196,12 @@ class SearchStore {
 
   private saveHistory() {
     if (typeof localStorage === 'undefined') return;
-    
+
     try {
-      localStorage.setItem('search_history', JSON.stringify(this.state.history));
+      localStorage.setItem(
+        'search_history',
+        JSON.stringify(this.state.history)
+      );
     } catch (error) {
       console.error('Failed to save search history:', error);
     }
@@ -191,7 +210,7 @@ class SearchStore {
   addToHistory(query: string) {
     const trimmed = query.trim();
     if (!trimmed || this.state.history.includes(trimmed)) return;
-    
+
     this.state.history = [trimmed, ...this.state.history].slice(0, MAX_HISTORY);
     this.saveHistory();
   }
@@ -215,7 +234,7 @@ class SearchStore {
       error: null,
       currentPage: 1,
       totalResults: 0,
-      history: this.loadHistory()
+      history: this.loadHistory(),
     };
   }
 }

--- a/laravel-svelte-port/svelte-ui/src/lib/stores/search.svelte.ts
+++ b/laravel-svelte-port/svelte-ui/src/lib/stores/search.svelte.ts
@@ -91,7 +91,7 @@ class SearchStore {
   async performSearch(
     query: string,
     filters: SearchFilters = {},
-    page: number = 1
+    pageNumber: number = 1
   ) {
     if (!query.trim()) {
       this.clearResults();
@@ -102,17 +102,17 @@ class SearchStore {
     this.state.filters = filters;
     this.state.isSearching = true;
     this.state.error = null;
-    this.state.currentPage = page;
+    this.state.currentPage = pageNumber;
 
     try {
       const response = await searchApi.search(
         this.currentAccountId,
         query,
         filters,
-        page
+        pageNumber
       );
 
-      if (page === 1) {
+      if (pageNumber === 1) {
         this.state.results = response.results;
       } else {
         this.state.results = [...this.state.results, ...response.results];

--- a/laravel-svelte-port/svelte-ui/src/routes/app/accounts/[accountId]/canned-responses/+page.svelte
+++ b/laravel-svelte-port/svelte-ui/src/routes/app/accounts/[accountId]/canned-responses/+page.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
   import { onMount } from 'svelte';
+  import { goto } from '$app/navigation';
+  import { page } from '$app/stores';
   import {
     Search,
     MessageSquare,
@@ -7,115 +9,54 @@
     Trash2,
     Copy,
     Plus,
+    AlertCircle,
   } from '@lucide/svelte';
   import * as Card from '$lib/components/ui/card';
-  import * as Tabs from '$lib/components/ui/tabs';
+  import * as Dialog from '$lib/components/ui/alert-dialog';
   import { Button } from '$lib/components/ui/button';
   import { Input } from '$lib/components/ui/input';
   import { Badge } from '$lib/components/ui/badge';
   import { Skeleton } from '$lib/components/ui/skeleton';
-
-  type Category = 'all' | 'general' | 'sales' | 'support' | 'billing';
-
-  interface CannedResponse {
-    id: number;
-    shortCode: string;
-    title: string;
-    content: string;
-    category: string;
-    updatedAt: string;
-  }
-
-  // State for canned responses (placeholder - will be replaced with store)
-  let cannedResponses = $state<CannedResponse[]>([
-    {
-      id: 1,
-      shortCode: '/hello',
-      title: 'Greeting',
-      content: 'Hello! How can I help you today?',
-      category: 'general',
-      updatedAt: '2024-01-03',
-    },
-    {
-      id: 2,
-      shortCode: '/pricing',
-      title: 'Pricing Information',
-      content:
-        'Our pricing plans start at $29/month for the Basic plan, $79/month for Pro, and $199/month for Enterprise. Would you like to learn more about any specific plan?',
-      category: 'sales',
-      updatedAt: '2024-01-02',
-    },
-    {
-      id: 3,
-      shortCode: '/troubleshoot',
-      title: 'Troubleshooting Steps',
-      content:
-        'Let me help you troubleshoot this issue. First, could you please try clearing your browser cache and cookies? Then, log out and log back in. If the issue persists, please let me know.',
-      category: 'support',
-      updatedAt: '2024-01-01',
-    },
-    {
-      id: 4,
-      shortCode: '/refund',
-      title: 'Refund Policy',
-      content:
-        'We offer a 30-day money-back guarantee. To process your refund, I will need your order number and the reason for the refund. Could you please provide those details?',
-      category: 'billing',
-      updatedAt: '2023-12-30',
-    },
-  ]);
+  import { cannedResponsesStore } from '$lib/stores/cannedResponses.svelte';
+  import { toast } from 'svelte-sonner';
 
   let searchQuery = $state('');
-  let activeCategory = $state<Category>('all');
-  let isLoading = $state(false);
+  let responseToDelete = $state<number | null>(null);
+  let showDeleteDialog = $state(false);
 
-  // Reactive filtered responses
-  const filteredResponses = $derived(() => {
-    let filtered = cannedResponses;
+  const accountId = $derived($page.params.accountId);
+  const cannedResponses = $derived(cannedResponsesStore.items);
+  const isLoading = $derived(cannedResponsesStore.isLoading);
+  const isDeleting = $derived(cannedResponsesStore.isDeleting);
+  const error = $derived(cannedResponsesStore.error);
 
-    // Filter by category
-    if (activeCategory !== 'all') {
-      filtered = filtered.filter(r => r.category === activeCategory);
-    }
-
-    // Filter by search query
-    if (searchQuery.trim()) {
-      const query = searchQuery.toLowerCase();
-      filtered = filtered.filter(
-        r =>
-          r.shortCode.toLowerCase().includes(query) ||
-          r.content.toLowerCase().includes(query)
-      );
-    }
-
-    return filtered;
+  onMount(async () => {
+    await cannedResponsesStore.fetch({ page: 1, perPage: 15 });
   });
 
-  // Get category count
-  function getCategoryCount(category: Category): number {
-    if (category === 'all') return cannedResponses.length;
-    return cannedResponses.filter(r => r.category === category).length;
+  async function handleSearch() {
+    await cannedResponsesStore.fetch({
+      page: 1,
+      perPage: 15,
+      search: searchQuery.trim() || undefined,
+    });
   }
 
-  // Copy short code to clipboard
-  function copyShortCode(code: string) {
-    navigator.clipboard.writeText(code);
-    // TODO: Show toast notification
+  async function copyShortCode(code: string) {
+    await navigator.clipboard.writeText(code);
+    toast.success('Short code copied to clipboard');
   }
 
-  // Truncate content
-  function truncate(text: string, maxLength: number): string {
-    if (text.length <= maxLength) return text;
-    return text.slice(0, maxLength) + '...';
+  async function confirmDelete() {
+    if (!responseToDelete) return;
+    const deleted = await cannedResponsesStore.delete(responseToDelete);
+    if (deleted) toast.success('Canned response deleted');
+    responseToDelete = null;
+    showDeleteDialog = false;
   }
-
-  onMount(() => {
-    // TODO: Fetch canned responses from store
-  });
 </script>
 
 <div class="max-w-[60rem] mx-auto p-6">
-  <!-- Header -->
   <div
     class="mb-6 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between"
   >
@@ -123,15 +64,17 @@
       <h1 class="text-3xl font-bold">Canned Responses</h1>
       <p class="text-muted-foreground">Save time with pre-written responses</p>
     </div>
-    <Button>
+    <Button
+      onclick={() =>
+        goto(`/app/accounts/${accountId}/settings/canned-responses/new`)}
+    >
       <Plus class="mr-2 h-4 w-4" />
       New Response
     </Button>
   </div>
 
-  <!-- Search -->
-  <div class="mb-6">
-    <div class="relative">
+  <div class="mb-6 flex gap-2">
+    <div class="relative flex-1">
       <Search
         class="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground"
       />
@@ -140,141 +83,136 @@
         placeholder="Search by short code or content..."
         bind:value={searchQuery}
         class="pl-10"
+        onkeydown={e => e.key === 'Enter' && handleSearch()}
       />
     </div>
+    <Button variant="outline" onclick={handleSearch}>Search</Button>
   </div>
 
-  <!-- Category tabs -->
-  <Tabs.Root value={activeCategory} class="mb-6">
-    <Tabs.List>
-      <Tabs.Trigger value="all" onclick={() => (activeCategory = 'all')}>
-        All ({getCategoryCount('all')})
-      </Tabs.Trigger>
-      <Tabs.Trigger
-        value="general"
-        onclick={() => (activeCategory = 'general')}
-      >
-        General ({getCategoryCount('general')})
-      </Tabs.Trigger>
-      <Tabs.Trigger value="sales" onclick={() => (activeCategory = 'sales')}>
-        Sales ({getCategoryCount('sales')})
-      </Tabs.Trigger>
-      <Tabs.Trigger
-        value="support"
-        onclick={() => (activeCategory = 'support')}
-      >
-        Support ({getCategoryCount('support')})
-      </Tabs.Trigger>
-      <Tabs.Trigger
-        value="billing"
-        onclick={() => (activeCategory = 'billing')}
-      >
-        Billing ({getCategoryCount('billing')})
-      </Tabs.Trigger>
-    </Tabs.List>
-  </Tabs.Root>
-
-  <!-- Response count -->
-  <div class="mb-4">
-    <p class="text-sm text-muted-foreground">
-      {filteredResponses().length}
-      {filteredResponses().length === 1 ? 'response' : 'responses'}
-    </p>
-  </div>
-
-  <!-- Loading state -->
   {#if isLoading}
     <div class="grid gap-4">
-      {#each Array(6) as _}
-        <Card.Root>
-          <Card.Content class="p-4">
-            <div class="space-y-3">
-              <Skeleton class="h-6 w-24" />
-              <Skeleton class="h-5 w-48" />
-              <Skeleton class="h-4 w-full" />
-              <Skeleton class="h-4 w-3/4" />
-            </div>
-          </Card.Content>
-        </Card.Root>
-      {/each}
+      {#each Array(6) as _}<Card.Root
+          ><Card.Content class="p-4"
+            ><Skeleton class="h-14 w-full" /></Card.Content
+          ></Card.Root
+        >{/each}
     </div>
-  {:else if filteredResponses().length === 0}
-    <!-- Empty state -->
+  {:else if error}
+    <Card.Root>
+      <Card.Content class="flex flex-col items-center justify-center py-12">
+        <AlertCircle class="mb-4 h-12 w-12 text-destructive" />
+        <h3 class="mb-2 text-lg font-semibold">
+          Unable to load canned responses
+        </h3>
+        <p class="mb-4 text-sm text-muted-foreground">{error}</p>
+        <Button
+          variant="outline"
+          onclick={() => cannedResponsesStore.fetch({ page: 1, perPage: 15 })}
+          >Retry</Button
+        >
+      </Card.Content>
+    </Card.Root>
+  {:else if cannedResponses.length === 0}
     <Card.Root>
       <Card.Content class="flex flex-col items-center justify-center py-12">
         <MessageSquare class="mb-4 h-12 w-12 text-muted-foreground" />
-        <h3 class="mb-2 text-lg font-semibold">
-          {searchQuery || activeCategory !== 'all'
-            ? 'No responses found'
-            : 'No canned responses yet'}
-        </h3>
-        <p class="mb-4 text-center text-sm text-muted-foreground">
-          {searchQuery || activeCategory !== 'all'
-            ? 'Try adjusting your filters or search query'
-            : 'Create canned responses to save time when replying to common questions'}
-        </p>
-        {#if !searchQuery && activeCategory === 'all'}
-          <Button>
-            <Plus class="mr-2 h-4 w-4" />
-            Create Response
-          </Button>
-        {/if}
+        <h3 class="mb-2 text-lg font-semibold">No canned responses found</h3>
       </Card.Content>
     </Card.Root>
   {:else}
-    <!-- Responses list -->
+    <div class="mb-4 text-sm text-muted-foreground">
+      {cannedResponsesStore.total} responses
+    </div>
     <div class="grid gap-4">
-      {#each filteredResponses() as response (response.id)}
+      {#each cannedResponses as response (response.id)}
         <Card.Root class="transition-colors hover:border-primary">
           <Card.Content class="p-4">
             <div class="flex items-start justify-between gap-4">
               <div class="flex-1 min-w-0">
-                <!-- Short code badge -->
-                <Badge variant="secondary" class="mb-2 font-mono text-xs">
-                  {response.shortCode}
-                </Badge>
-
-                <!-- Title -->
-                <h3 class="mb-2 font-semibold">{response.title}</h3>
-
-                <!-- Content preview -->
-                <p class="mb-3 text-sm text-muted-foreground">
-                  {truncate(response.content, 120)}
-                </p>
-
-                <!-- Category and date -->
-                <div
-                  class="flex flex-wrap items-center gap-2 text-xs text-muted-foreground"
+                <Badge variant="secondary" class="mb-2 font-mono text-xs"
+                  >{response.shortCode}</Badge
                 >
-                  <Badge variant="outline" class="capitalize"
-                    >{response.category}</Badge
-                  >
-                  <span>•</span>
-                  <span>Updated {response.updatedAt}</span>
-                </div>
+                <p class="mb-3 text-sm text-muted-foreground">
+                  {response.content}
+                </p>
+                <span class="text-xs text-muted-foreground"
+                  >Updated {new Date(
+                    response.updatedAt
+                  ).toLocaleDateString()}</span
+                >
               </div>
-
-              <!-- Actions -->
               <div class="flex gap-2">
                 <Button
                   variant="outline"
                   size="sm"
                   onclick={() => copyShortCode(response.shortCode)}
-                  title="Copy short code"
+                  ><Copy class="h-4 w-4" /></Button
                 >
-                  <Copy class="h-4 w-4" />
-                </Button>
-                <Button variant="outline" size="sm" title="Edit response">
-                  <Edit class="h-4 w-4" />
-                </Button>
-                <Button variant="outline" size="sm" title="Delete response">
-                  <Trash2 class="h-4 w-4" />
-                </Button>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onclick={() =>
+                    goto(
+                      `/app/accounts/${accountId}/settings/canned-responses/${response.id}/edit`
+                    )}><Edit class="h-4 w-4" /></Button
+                >
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onclick={() => {
+                    responseToDelete = response.id;
+                    showDeleteDialog = true;
+                  }}><Trash2 class="h-4 w-4" /></Button
+                >
               </div>
             </div>
           </Card.Content>
         </Card.Root>
       {/each}
     </div>
+
+    <div class="mt-6 flex justify-between">
+      <Button
+        variant="outline"
+        disabled={cannedResponsesStore.currentPage <= 1}
+        onclick={() =>
+          cannedResponsesStore.fetch({
+            page: cannedResponsesStore.currentPage - 1,
+            perPage: cannedResponsesStore.perPage,
+            search: searchQuery.trim() || undefined,
+          })}>Previous</Button
+      >
+      <Button
+        variant="outline"
+        disabled={cannedResponsesStore.currentPage >=
+          cannedResponsesStore.lastPage}
+        onclick={() =>
+          cannedResponsesStore.fetch({
+            page: cannedResponsesStore.currentPage + 1,
+            perPage: cannedResponsesStore.perPage,
+            search: searchQuery.trim() || undefined,
+          })}>Next</Button
+      >
+    </div>
   {/if}
 </div>
+
+<Dialog.Root bind:open={showDeleteDialog}>
+  <Dialog.Content>
+    <Dialog.Header>
+      <Dialog.Title>Delete canned response?</Dialog.Title>
+      <Dialog.Description>This action cannot be undone.</Dialog.Description>
+    </Dialog.Header>
+    <Dialog.Footer>
+      <Dialog.Cancel
+        onclick={() => {
+          responseToDelete = null;
+          showDeleteDialog = false;
+        }}>Cancel</Dialog.Cancel
+      >
+      <Dialog.Action onclick={confirmDelete} disabled={isDeleting}
+        >Delete</Dialog.Action
+      >
+    </Dialog.Footer>
+  </Dialog.Content>
+</Dialog.Root>

--- a/laravel-svelte-port/svelte-ui/src/routes/app/accounts/[accountId]/canned-responses/+page.svelte
+++ b/laravel-svelte-port/svelte-ui/src/routes/app/accounts/[accountId]/canned-responses/+page.svelte
@@ -32,6 +32,7 @@
 
   $effect(() => {
     if (accountId) {
+      searchQuery = '';
       cannedResponsesStore.fetch({ page: 1, perPage: 15 });
     }
   });
@@ -147,9 +148,14 @@
                   {truncate(response.content, 120)}
                 </p>
                 <span class="text-xs text-muted-foreground"
-                  >Updated {new Date(
-                    response.updatedAt
-                  ).toLocaleDateString()}</span
+                  >Updated {(() => {
+                    const fallback = response.createdAt ?? 'N/A';
+                    const timestamp = response.updatedAt ?? fallback;
+                    const date = new Date(timestamp);
+                    return Number.isNaN(date.getTime())
+                      ? fallback
+                      : date.toLocaleDateString();
+                  })()}</span
                 >
               </div>
               <div class="flex gap-2">

--- a/laravel-svelte-port/svelte-ui/src/routes/app/accounts/[accountId]/canned-responses/+page.svelte
+++ b/laravel-svelte-port/svelte-ui/src/routes/app/accounts/[accountId]/canned-responses/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { goto } from '$app/navigation';
-  import { page } from '$app/stores';
+  import { page } from '$app/state';
   import {
     Search,
     MessageSquare,
@@ -24,7 +24,7 @@
   let responseToDelete = $state<number | null>(null);
   let showDeleteDialog = $state(false);
 
-  const accountId = $derived($page.params.accountId);
+  const accountId = $derived(page.params.accountId);
   const cannedResponses = $derived(cannedResponsesStore.items);
   const isLoading = $derived(cannedResponsesStore.isLoading);
   const isDeleting = $derived(cannedResponsesStore.isDeleting);

--- a/laravel-svelte-port/svelte-ui/src/routes/app/accounts/[accountId]/canned-responses/+page.svelte
+++ b/laravel-svelte-port/svelte-ui/src/routes/app/accounts/[accountId]/canned-responses/+page.svelte
@@ -114,8 +114,12 @@
         <p class="mb-4 text-sm text-muted-foreground">{error}</p>
         <Button
           variant="outline"
-          onclick={() => cannedResponsesStore.fetch({ page: 1, perPage: 15 })}
-          >Retry</Button
+          onclick={() =>
+            cannedResponsesStore.fetch({
+              page: 1,
+              perPage: 15,
+              search: searchQuery.trim() || undefined,
+            })}>Retry</Button
         >
       </Card.Content>
     </Card.Root>
@@ -159,8 +163,9 @@
                   variant="outline"
                   size="sm"
                   onclick={() =>
-                    goto(`/app/accounts/${accountId}/settings/macros`)}
-                  ><Edit class="h-4 w-4" /></Button
+                    goto(
+                      `/app/accounts/${accountId}/settings/macros?edit=${response.id}`
+                    )}><Edit class="h-4 w-4" /></Button
                 >
                 <Button
                   variant="outline"

--- a/laravel-svelte-port/svelte-ui/src/routes/app/accounts/[accountId]/canned-responses/+page.svelte
+++ b/laravel-svelte-port/svelte-ui/src/routes/app/accounts/[accountId]/canned-responses/+page.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import { onMount } from 'svelte';
   import { goto } from '$app/navigation';
   import { page } from '$app/stores';
   import {
@@ -19,6 +18,7 @@
   import { Skeleton } from '$lib/components/ui/skeleton';
   import { cannedResponsesStore } from '$lib/stores/cannedResponses.svelte';
   import { toast } from 'svelte-sonner';
+  import { truncate } from '$lib/utils/format';
 
   let searchQuery = $state('');
   let responseToDelete = $state<number | null>(null);
@@ -30,8 +30,10 @@
   const isDeleting = $derived(cannedResponsesStore.isDeleting);
   const error = $derived(cannedResponsesStore.error);
 
-  onMount(async () => {
-    await cannedResponsesStore.fetch({ page: 1, perPage: 15 });
+  $effect(() => {
+    if (accountId) {
+      cannedResponsesStore.fetch({ page: 1, perPage: 15 });
+    }
   });
 
   async function handleSearch() {
@@ -43,14 +45,22 @@
   }
 
   async function copyShortCode(code: string) {
-    await navigator.clipboard.writeText(code);
-    toast.success('Short code copied to clipboard');
+    try {
+      await navigator.clipboard.writeText(code);
+      toast.success('Short code copied to clipboard');
+    } catch {
+      toast.error('Failed to copy to clipboard');
+    }
   }
 
   async function confirmDelete() {
     if (!responseToDelete) return;
     const deleted = await cannedResponsesStore.delete(responseToDelete);
     if (deleted) toast.success('Canned response deleted');
+    else
+      toast.error(
+        cannedResponsesStore.error ?? 'Failed to delete canned response'
+      );
     responseToDelete = null;
     showDeleteDialog = false;
   }
@@ -64,10 +74,7 @@
       <h1 class="text-3xl font-bold">Canned Responses</h1>
       <p class="text-muted-foreground">Save time with pre-written responses</p>
     </div>
-    <Button
-      onclick={() =>
-        goto(`/app/accounts/${accountId}/settings/canned-responses/new`)}
-    >
+    <Button onclick={() => goto(`/app/accounts/${accountId}/settings/macros`)}>
       <Plus class="mr-2 h-4 w-4" />
       New Response
     </Button>
@@ -133,7 +140,7 @@
                   >{response.shortCode}</Badge
                 >
                 <p class="mb-3 text-sm text-muted-foreground">
-                  {response.content}
+                  {truncate(response.content, 120)}
                 </p>
                 <span class="text-xs text-muted-foreground"
                   >Updated {new Date(
@@ -152,9 +159,8 @@
                   variant="outline"
                   size="sm"
                   onclick={() =>
-                    goto(
-                      `/app/accounts/${accountId}/settings/canned-responses/${response.id}/edit`
-                    )}><Edit class="h-4 w-4" /></Button
+                    goto(`/app/accounts/${accountId}/settings/macros`)}
+                  ><Edit class="h-4 w-4" /></Button
                 >
                 <Button
                   variant="outline"

--- a/laravel-svelte-port/svelte-ui/src/routes/app/accounts/[accountId]/integrations/+page.svelte
+++ b/laravel-svelte-port/svelte-ui/src/routes/app/accounts/[accountId]/integrations/+page.svelte
@@ -1,123 +1,41 @@
 <script lang="ts">
   import { onMount } from 'svelte';
+  import { goto } from '$app/navigation';
+  import { page } from '$app/stores';
   import {
-    MessageCircle,
-    Mail,
-    Facebook,
-    Twitter,
-    Send,
     Puzzle,
-    Zap,
-    Webhook,
     Plus,
     Settings,
     CheckCircle,
+    AlertCircle,
   } from '@lucide/svelte';
   import * as Card from '$lib/components/ui/card';
   import { Button } from '$lib/components/ui/button';
   import { Badge } from '$lib/components/ui/badge';
   import { Skeleton } from '$lib/components/ui/skeleton';
+  import { integrationsStore } from '$lib/stores/integrations.svelte';
+  import { toast } from 'svelte-sonner';
 
-  type IntegrationStatus = 'connected' | 'available';
+  const accountId = $derived($page.params.accountId);
+  const integrations = $derived(integrationsStore.integrations);
+  const isLoading = $derived(integrationsStore.isLoading);
+  const error = $derived(integrationsStore.error);
 
-  interface Integration {
-    id: string;
-    name: string;
-    description: string;
-    icon: any;
-    status: IntegrationStatus;
-  }
-
-  // State for integrations (placeholder - will be replaced with store)
-  let integrations = $state<Integration[]>([
-    {
-      id: 'slack',
-      name: 'Slack',
-      description:
-        'Get notified about new conversations in your Slack workspace',
-      icon: MessageCircle,
-      status: 'connected',
-    },
-    {
-      id: 'whatsapp',
-      name: 'WhatsApp',
-      description: 'Connect your WhatsApp Business account to receive messages',
-      icon: MessageCircle,
-      status: 'available',
-    },
-    {
-      id: 'facebook',
-      name: 'Facebook Messenger',
-      description: 'Respond to Facebook messages directly from Chatwoot',
-      icon: Facebook,
-      status: 'available',
-    },
-    {
-      id: 'email',
-      name: 'Email',
-      description: 'Forward emails to your Chatwoot inbox',
-      icon: Mail,
-      status: 'connected',
-    },
-    {
-      id: 'telegram',
-      name: 'Telegram',
-      description: 'Connect your Telegram bot to receive messages',
-      icon: Send,
-      status: 'available',
-    },
-    {
-      id: 'twitter',
-      name: 'Twitter',
-      description: 'Respond to Twitter mentions and direct messages',
-      icon: Twitter,
-      status: 'available',
-    },
-    {
-      id: 'zapier',
-      name: 'Zapier',
-      description: 'Connect with 5000+ apps using Zapier workflows',
-      icon: Zap,
-      status: 'available',
-    },
-    {
-      id: 'webhooks',
-      name: 'Webhooks',
-      description: 'Send real-time data to external services',
-      icon: Webhook,
-      status: 'connected',
-    },
-  ]);
-
-  let isLoading = $state(false);
-
-  // Get connected integrations count
-  const connectedCount = $derived(
-    integrations.filter(i => i.status === 'connected').length
-  );
-
-  // Get badge variant based on status
-  function getBadgeVariant(status: IntegrationStatus): 'default' | 'secondary' {
-    return status === 'connected' ? 'default' : 'secondary';
-  }
-
-  // Get button text based on status
-  function getButtonText(status: IntegrationStatus): string {
-    return status === 'connected' ? 'Configure' : 'Connect';
-  }
-
-  // Get badge icon
-  function getBadgeIcon(status: IntegrationStatus) {
-    return status === 'connected' ? CheckCircle : Plus;
-  }
-
-  onMount(() => {
-    // TODO: Fetch integrations from store
+  onMount(async () => {
+    await integrationsStore.fetch();
   });
+
+  function handleIntegrationAction(status: 'connected' | 'available') {
+    if (status === 'connected') {
+      goto(`/app/accounts/${accountId}/settings/inboxes`);
+      return;
+    }
+
+    toast.info('Integration setup flow will be available in a next iteration.');
+  }
 </script>
 
 <div class="container mx-auto p-6">
-  <!-- Header -->
   <div
     class="mb-6 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between"
   >
@@ -129,86 +47,77 @@
     </div>
   </div>
 
-  <!-- Integration count -->
   <div class="mb-4">
     <p class="text-sm text-muted-foreground">
-      {connectedCount} of {integrations.length} integrations connected
+      {integrationsStore.connectedCount} of {integrations.length} integrations connected
     </p>
   </div>
 
-  <!-- Loading state -->
   {#if isLoading}
     <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
       {#each Array(6) as _}
-        <Card.Root>
-          <Card.Content class="p-6">
-            <div class="space-y-3">
-              <Skeleton class="h-12 w-12 rounded-lg" />
-              <Skeleton class="h-6 w-32" />
-              <Skeleton class="h-4 w-full" />
-              <Skeleton class="h-9 w-24" />
-            </div>
-          </Card.Content>
-        </Card.Root>
+        <Card.Root
+          ><Card.Content class="p-6"
+            ><Skeleton class="h-24 w-full" /></Card.Content
+          ></Card.Root
+        >
       {/each}
     </div>
+  {:else if error}
+    <Card.Root>
+      <Card.Content class="flex flex-col items-center justify-center py-12">
+        <AlertCircle class="mb-4 h-12 w-12 text-destructive" />
+        <h3 class="mb-2 text-lg font-semibold">Unable to load integrations</h3>
+        <p class="mb-4 text-sm text-muted-foreground">{error}</p>
+        <Button variant="outline" onclick={() => integrationsStore.fetch()}
+          >Retry</Button
+        >
+      </Card.Content>
+    </Card.Root>
   {:else if integrations.length === 0}
-    <!-- Empty state -->
     <Card.Root>
       <Card.Content class="flex flex-col items-center justify-center py-12">
         <Puzzle class="mb-4 h-12 w-12 text-muted-foreground" />
         <h3 class="mb-2 text-lg font-semibold">No integrations available</h3>
-        <p class="text-center text-sm text-muted-foreground">
-          Check back later for new integrations
-        </p>
       </Card.Content>
     </Card.Root>
   {:else}
-    <!-- Integrations grid -->
     <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
       {#each integrations as integration (integration.id)}
-        {@const IntegrationIcon = integration.icon}
-        {@const BadgeIcon = getBadgeIcon(integration.status)}
-        <Card.Root class="transition-all hover:scale-105 hover:shadow-md">
+        <Card.Root class="transition-all hover:shadow-md">
           <Card.Content class="p-6">
-            <!-- Icon -->
-            <div
-              class="mb-4 flex h-12 w-12 items-center justify-center rounded-lg bg-primary/10 text-primary"
-            >
-              <IntegrationIcon class="h-6 w-6" />
-            </div>
-
-            <!-- Name and badge -->
             <div class="mb-2 flex items-center gap-2">
               <h3 class="font-semibold">{integration.name}</h3>
               <Badge
-                variant={getBadgeVariant(integration.status)}
+                variant={integration.status === 'connected'
+                  ? 'default'
+                  : 'secondary'}
                 class="gap-1 text-xs"
               >
-                <BadgeIcon class="h-3 w-3" />
-                {integration.status === 'connected' ? 'Connected' : 'Available'}
+                <CheckCircle class="h-3 w-3" />
+                {integration.status}
               </Badge>
             </div>
-
-            <!-- Description -->
-            <p class="mb-4 text-sm text-muted-foreground">
-              {integration.description}
-            </p>
-
-            <!-- Action button -->
+            {#if integration.description}
+              <p class="mb-4 text-sm text-muted-foreground">
+                {integration.description}
+              </p>
+            {/if}
             <Button
               variant={integration.status === 'connected'
                 ? 'secondary'
                 : 'default'}
               size="sm"
               class="w-full"
+              onclick={() => handleIntegrationAction(integration.status)}
             >
               {#if integration.status === 'connected'}
                 <Settings class="mr-2 h-4 w-4" />
+                Configure
               {:else}
                 <Plus class="mr-2 h-4 w-4" />
+                Connect
               {/if}
-              {getButtonText(integration.status)}
             </Button>
           </Card.Content>
         </Card.Root>

--- a/laravel-svelte-port/svelte-ui/src/routes/app/accounts/[accountId]/integrations/+page.svelte
+++ b/laravel-svelte-port/svelte-ui/src/routes/app/accounts/[accountId]/integrations/+page.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import { onMount } from 'svelte';
   import { goto } from '$app/navigation';
   import { page } from '$app/stores';
   import {
@@ -21,8 +20,10 @@
   const isLoading = $derived(integrationsStore.isLoading);
   const error = $derived(integrationsStore.error);
 
-  onMount(async () => {
-    await integrationsStore.fetch();
+  $effect(() => {
+    if (accountId) {
+      integrationsStore.fetch();
+    }
   });
 
   function handleIntegrationAction(status: 'connected' | 'available') {
@@ -45,12 +46,6 @@
         Connect your favorite tools and channels
       </p>
     </div>
-  </div>
-
-  <div class="mb-4">
-    <p class="text-sm text-muted-foreground">
-      {integrationsStore.connectedCount} of {integrations.length} integrations connected
-    </p>
   </div>
 
   {#if isLoading}
@@ -82,6 +77,12 @@
       </Card.Content>
     </Card.Root>
   {:else}
+    <div class="mb-4">
+      <p class="text-sm text-muted-foreground">
+        {integrationsStore.connectedCount} of {integrations.length} integrations connected
+      </p>
+    </div>
+
     <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
       {#each integrations as integration (integration.id)}
         <Card.Root class="transition-all hover:shadow-md">

--- a/laravel-svelte-port/svelte-ui/src/routes/app/accounts/[accountId]/integrations/+page.svelte
+++ b/laravel-svelte-port/svelte-ui/src/routes/app/accounts/[accountId]/integrations/+page.svelte
@@ -86,6 +86,19 @@
       {#each integrations as integration (integration.id)}
         <Card.Root class="transition-all hover:shadow-md">
           <Card.Content class="p-6">
+            <div
+              class="mb-4 flex h-12 w-12 items-center justify-center rounded-lg bg-primary/10"
+            >
+              {#if integration.logo}
+                <img
+                  src={integration.logo}
+                  alt={`${integration.name} logo`}
+                  class="h-8 w-8 rounded"
+                />
+              {:else}
+                <Puzzle class="h-6 w-6 text-primary" />
+              {/if}
+            </div>
             <div class="mb-2 flex items-center gap-2">
               <h3 class="font-semibold">{integration.name}</h3>
               <Badge
@@ -94,7 +107,9 @@
                   : 'secondary'}
                 class="gap-1 text-xs"
               >
-                <CheckCircle class="h-3 w-3" />
+                {#if integration.status === 'connected'}
+                  <CheckCircle class="h-3 w-3" />
+                {/if}
                 {integration.status}
               </Badge>
             </div>

--- a/laravel-svelte-port/svelte-ui/src/routes/app/accounts/[accountId]/search/+page.svelte
+++ b/laravel-svelte-port/svelte-ui/src/routes/app/accounts/[accountId]/search/+page.svelte
@@ -24,6 +24,11 @@
       return;
     }
 
+    if (result.type === 'message' && result.conversationId) {
+      goto(`/app/accounts/${accountId}/conversations/${result.conversationId}`);
+      return;
+    }
+
     if (result.type === 'contact' && result.contactId) {
       goto(`/app/accounts/${accountId}/contacts/${result.contactId}`);
     }

--- a/laravel-svelte-port/svelte-ui/src/routes/app/accounts/[accountId]/search/+page.svelte
+++ b/laravel-svelte-port/svelte-ui/src/routes/app/accounts/[accountId]/search/+page.svelte
@@ -1,18 +1,32 @@
 <script lang="ts">
-  import { Input } from "$lib/components/ui/input";
-  import { Button } from "$lib/components/ui/button";
-  import { Search } from "lucide-svelte";
-  import { page } from "$app/stores";
-  
-  let searchQuery = $state($page.url.searchParams.get('q') || '');
-  let isSearching = $state(false);
+  import { goto } from '$app/navigation';
+  import { page } from '$app/stores';
+  import { Input } from '$lib/components/ui/input';
+  import { Button } from '$lib/components/ui/button';
+  import * as Card from '$lib/components/ui/card';
+  import { Search, AlertCircle } from 'lucide-svelte';
+  import { searchStore } from '$lib/stores/search.svelte';
 
-  function handleSearch() {
-    isSearching = true;
-    // TODO: Implement actual search logic using API
-    setTimeout(() => {
-        isSearching = false;
-    }, 500);
+  let searchQuery = $state($page.url.searchParams.get('q') || '');
+
+  const accountId = $derived($page.params.accountId);
+  const results = $derived(searchStore.results);
+  const isSearching = $derived(searchStore.isSearching);
+  const error = $derived(searchStore.error);
+
+  async function handleSearch() {
+    await searchStore.performSearch(searchQuery.trim());
+  }
+
+  function openResult(result: (typeof results)[number]) {
+    if (result.type === 'conversation' && result.conversationId) {
+      goto(`/app/accounts/${accountId}/conversations/${result.conversationId}`);
+      return;
+    }
+
+    if (result.type === 'contact' && result.contactId) {
+      goto(`/app/accounts/${accountId}/contacts/${result.contactId}`);
+    }
   }
 </script>
 
@@ -25,19 +39,62 @@
         placeholder="Search conversations, contacts..."
         class="pl-9"
         bind:value={searchQuery}
-        onkeydown={(e) => e.key === 'Enter' && handleSearch()}
+        onkeydown={e => e.key === 'Enter' && handleSearch()}
       />
     </div>
-    <Button onclick={handleSearch} disabled={isSearching}>
+    <Button
+      onclick={handleSearch}
+      disabled={isSearching || !searchQuery.trim()}
+    >
       {isSearching ? 'Searching...' : 'Search'}
     </Button>
   </div>
 
-  <div class="flex-1 border rounded-lg p-8 flex items-center justify-center text-muted-foreground">
-    {#if searchQuery}
-        <span>Search results for "{searchQuery}" will appear here.</span>
-    {:else}
-        <span>Type to search...</span>
-    {/if}
-  </div>
+  {#if error}
+    <Card.Root>
+      <Card.Content class="p-8 flex flex-col items-center gap-3">
+        <AlertCircle class="h-8 w-8 text-destructive" />
+        <p class="text-sm text-muted-foreground">{error}</p>
+      </Card.Content>
+    </Card.Root>
+  {:else if isSearching}
+    <div class="border rounded-lg p-8 text-muted-foreground">Searching...</div>
+  {:else if !searchQuery.trim()}
+    <div
+      class="border rounded-lg p-8 flex items-center justify-center text-muted-foreground"
+    >
+      Type to search...
+    </div>
+  {:else if results.length === 0}
+    <div
+      class="border rounded-lg p-8 flex items-center justify-center text-muted-foreground"
+    >
+      No results found for "{searchQuery}"
+    </div>
+  {:else}
+    <div class="space-y-3">
+      {#each results as result (result.type + result.id)}
+        <Card.Root
+          class="cursor-pointer hover:border-primary"
+          onclick={() => openResult(result)}
+        >
+          <Card.Content class="p-4">
+            <p class="font-medium">{result.title}</p>
+            {#if result.description}
+              <p class="text-sm text-muted-foreground">{result.description}</p>
+            {/if}
+          </Card.Content>
+        </Card.Root>
+      {/each}
+      {#if results.length < searchStore.totalResults}
+        <Button
+          variant="outline"
+          onclick={() => searchStore.loadMore()}
+          disabled={isSearching}
+        >
+          Load more
+        </Button>
+      {/if}
+    </div>
+  {/if}
 </div>

--- a/laravel-svelte-port/svelte-ui/src/routes/app/accounts/[accountId]/settings/billing/+page.svelte
+++ b/laravel-svelte-port/svelte-ui/src/routes/app/accounts/[accountId]/settings/billing/+page.svelte
@@ -1,57 +1,37 @@
 <script lang="ts">
-  /**
-   * Billing Settings Page
-   * View and manage billing information
-   */
-
+  import { onMount } from 'svelte';
+  import { goto } from '$app/navigation';
+  import { page } from '$app/stores';
   import * as Card from '$lib/components/ui/card';
   import { Button } from '$lib/components/ui/button';
   import { Badge } from '$lib/components/ui/badge';
+  import { Skeleton } from '$lib/components/ui/skeleton';
+  import { billingStore } from '$lib/stores/billing.svelte';
+  import { toast } from 'svelte-sonner';
+  import { AlertCircle } from '@lucide/svelte';
 
-  let currentPlan = $state({
-    name: 'Pro',
-    price: 49,
-    billingCycle: 'monthly',
-    features: [
-      'Unlimited conversations',
-      '10 team members',
-      'Advanced analytics',
-      'Custom branding',
-      'Priority support',
-    ],
+  const accountId = $derived($page.params.accountId);
+  const currentPlan = $derived(billingStore.plan);
+  const invoices = $derived(billingStore.invoices);
+  const isLoading = $derived(billingStore.isLoading);
+  const error = $derived(billingStore.error);
+
+  onMount(async () => {
+    await billingStore.fetch();
   });
 
-  let invoices = $state([
-    {
-      id: 'INV-001',
-      date: '2024-01-01',
-      amount: 49,
-      status: 'paid',
-    },
-    {
-      id: 'INV-002',
-      date: '2023-12-01',
-      amount: 49,
-      status: 'paid',
-    },
-  ]);
-
   function handleUpgrade() {
-    alert('Upgrade functionality coming soon!');
+    goto(`/app/accounts/${accountId}/settings/account`);
+    toast.info('Redirected to account settings to manage your plan.');
   }
 
-  function handleDownload(invoiceId: string) {
-    alert(`Downloading invoice ${invoiceId}`);
-  }
+  function handleDownload(invoiceId: string, downloadUrl?: string) {
+    if (!downloadUrl) {
+      toast.error(`Invoice ${invoiceId} is not available for download yet.`);
+      return;
+    }
 
-  function getStatusBadge(status: string) {
-    if (status === 'paid') return 'bg-green-100 text-green-800';
-    if (status === 'pending') return 'bg-yellow-100 text-yellow-800';
-    return 'bg-red-100 text-red-800';
-  }
-
-  function formatDate(dateString: string) {
-    return new Date(dateString).toLocaleDateString();
+    window.open(downloadUrl, '_blank', 'noopener,noreferrer');
   }
 </script>
 
@@ -63,127 +43,98 @@
     </p>
   </div>
 
-  <Card.Root>
-    <Card.Header>
-      <Card.Title>Current Plan</Card.Title>
-      <Card.Description>Your active subscription plan</Card.Description>
-    </Card.Header>
-    <Card.Content>
-      <div class="flex items-center justify-between mb-6">
-        <div>
-          <h3 class="text-2xl font-bold">{currentPlan.name} Plan</h3>
-          <p class="text-gray-600 mt-1">
-            ${currentPlan.price} / {currentPlan.billingCycle}
-          </p>
-        </div>
-        <Badge variant="default" class="text-sm px-4 py-2">Active</Badge>
-      </div>
-
-      <div class="space-y-2 mb-6">
-        <h4 class="font-semibold">Included Features:</h4>
-        <ul class="space-y-2">
-          {#each currentPlan.features as feature}
-            <li class="flex items-center gap-2">
-              <svg
-                class="h-5 w-5 text-green-600"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
-              >
-                <path
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                  d="M5 13l4 4L19 7"
-                />
-              </svg>
-              <span>{feature}</span>
-            </li>
-          {/each}
-        </ul>
-      </div>
-
-      <div class="flex gap-2">
-        <Button onclick={handleUpgrade}>Upgrade Plan</Button>
-        <Button variant="outline">Manage Subscription</Button>
-      </div>
-    </Card.Content>
-  </Card.Root>
-
-  <Card.Root>
-    <Card.Header>
-      <Card.Title>Payment Method</Card.Title>
-      <Card.Description>Your payment information</Card.Description>
-    </Card.Header>
-    <Card.Content>
-      <div class="flex items-center justify-between">
-        <div class="flex items-center gap-4">
-          <div class="h-12 w-16 bg-gray-100 rounded flex items-center justify-center">
-            <svg class="h-8 w-8" viewBox="0 0 24 24" fill="none">
-              <rect
-                x="2"
-                y="5"
-                width="20"
-                height="14"
-                rx="2"
-                stroke="currentColor"
-                stroke-width="2"
-              />
-              <line
-                x1="2"
-                y1="10"
-                x2="22"
-                y2="10"
-                stroke="currentColor"
-                stroke-width="2"
-              />
-            </svg>
+  {#if isLoading}
+    <Card.Root
+      ><Card.Content class="p-6"><Skeleton class="h-40 w-full" /></Card.Content
+      ></Card.Root
+    >
+  {:else if error}
+    <Card.Root>
+      <Card.Content class="py-12 flex flex-col items-center">
+        <AlertCircle class="h-12 w-12 mb-4 text-destructive" />
+        <h3 class="text-lg font-semibold mb-2">
+          Unable to load billing information
+        </h3>
+        <p class="text-sm text-muted-foreground mb-4">{error}</p>
+        <Button variant="outline" onclick={() => billingStore.fetch()}
+          >Retry</Button
+        >
+      </Card.Content>
+    </Card.Root>
+  {:else}
+    <Card.Root>
+      <Card.Header>
+        <Card.Title>Current Plan</Card.Title>
+      </Card.Header>
+      <Card.Content>
+        {#if currentPlan}
+          <div class="flex items-center justify-between mb-6">
+            <div>
+              <h3 class="text-2xl font-bold">{currentPlan.name}</h3>
+              <p class="text-gray-600 mt-1">
+                ${currentPlan.amount} / {currentPlan.billingCycle}
+              </p>
+            </div>
+            <Badge variant="default" class="text-sm px-4 py-2"
+              >{currentPlan.status}</Badge
+            >
           </div>
-          <div>
-            <p class="font-semibold">•••• •••• •••• 4242</p>
-            <p class="text-sm text-gray-600">Expires 12/2025</p>
-          </div>
-        </div>
-        <Button variant="outline">Update</Button>
-      </div>
-    </Card.Content>
-  </Card.Root>
 
-  <Card.Root>
-    <Card.Header>
-      <Card.Title>Invoice History</Card.Title>
-      <Card.Description>View and download your past invoices</Card.Description>
-    </Card.Header>
-    <Card.Content>
-      <div class="space-y-3">
-        {#each invoices as invoice}
-          <div class="flex items-center justify-between border-b pb-3">
-            <div class="flex items-center gap-4">
-              <div>
-                <p class="font-semibold">{invoice.id}</p>
-                <p class="text-sm text-gray-600">{formatDate(invoice.date)}</p>
+          <div class="space-y-2 mb-6">
+            <h4 class="font-semibold">Included Features:</h4>
+            <ul class="space-y-2">
+              {#each currentPlan.features as feature}
+                <li>{feature}</li>
+              {/each}
+            </ul>
+          </div>
+        {:else}
+          <p class="text-sm text-muted-foreground">No active plan found.</p>
+        {/if}
+
+        <div class="flex gap-2">
+          <Button onclick={handleUpgrade}>Upgrade Plan</Button>
+          <Button variant="outline" onclick={handleUpgrade}
+            >Manage Subscription</Button
+          >
+        </div>
+      </Card.Content>
+    </Card.Root>
+
+    <Card.Root>
+      <Card.Header>
+        <Card.Title>Invoice History</Card.Title>
+      </Card.Header>
+      <Card.Content>
+        {#if invoices.length === 0}
+          <p class="text-sm text-muted-foreground">No invoices available.</p>
+        {:else}
+          <div class="space-y-3">
+            {#each invoices as invoice}
+              <div class="flex items-center justify-between border-b pb-3">
+                <div>
+                  <p class="font-semibold">{invoice.id}</p>
+                  <p class="text-sm text-gray-600">
+                    {new Date(invoice.date).toLocaleDateString()}
+                  </p>
+                </div>
+                <div class="flex items-center gap-3">
+                  <span class="font-semibold">${invoice.amount}</span>
+                  <Badge variant="outline">{invoice.status}</Badge>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onclick={() =>
+                      handleDownload(invoice.id, invoice.downloadUrl)}
+                  >
+                    Download
+                  </Button>
+                </div>
               </div>
-            </div>
-            <div class="flex items-center gap-3">
-              <span class="font-semibold">${invoice.amount}.00</span>
-              <span
-                class="px-2 py-1 rounded text-xs font-medium {getStatusBadge(
-                  invoice.status
-                )}"
-              >
-                {invoice.status}
-              </span>
-              <Button
-                variant="outline"
-                size="sm"
-                onclick={() => handleDownload(invoice.id)}
-              >
-                Download
-              </Button>
-            </div>
+            {/each}
           </div>
-        {/each}
-      </div>
-    </Card.Content>
-  </Card.Root>
+        {/if}
+      </Card.Content>
+    </Card.Root>
+  {/if}
 </div>

--- a/laravel-svelte-port/svelte-ui/src/routes/app/accounts/[accountId]/team/+page.svelte
+++ b/laravel-svelte-port/svelte-ui/src/routes/app/accounts/[accountId]/team/+page.svelte
@@ -1,13 +1,14 @@
 <script lang="ts">
   import { onMount } from 'svelte';
+  import { goto } from '$app/navigation';
+  import { page } from '$app/stores';
   import {
     Search,
     Mail,
     Shield,
     UserCheck,
-    Edit,
-    Trash2,
     UserPlus,
+    AlertCircle,
   } from '@lucide/svelte';
   import * as Card from '$lib/components/ui/card';
   import * as Avatar from '$lib/components/ui/avatar';
@@ -15,47 +16,15 @@
   import { Input } from '$lib/components/ui/input';
   import { Badge } from '$lib/components/ui/badge';
   import { Skeleton } from '$lib/components/ui/skeleton';
-
-  // State for team members (placeholder - will be replaced with teamsStore)
-  let teamMembers = $state([
-    {
-      id: 1,
-      name: 'John Doe',
-      email: 'john@example.com',
-      role: 'Admin',
-      availability: 'Online',
-      avatar: null,
-    },
-    {
-      id: 2,
-      name: 'Jane Smith',
-      email: 'jane@example.com',
-      role: 'Agent',
-      availability: 'Online',
-      avatar: null,
-    },
-    {
-      id: 3,
-      name: 'Bob Johnson',
-      email: 'bob@example.com',
-      role: 'Agent',
-      availability: 'Away',
-      avatar: null,
-    },
-    {
-      id: 4,
-      name: 'Alice Williams',
-      email: 'alice@example.com',
-      role: 'Viewer',
-      availability: 'Offline',
-      avatar: null,
-    },
-  ]);
+  import { agentsStore } from '$lib/stores/agents.svelte';
 
   let searchQuery = $state('');
-  let isLoading = $state(false);
 
-  // Reactive filtered members
+  const accountId = $derived($page.params.accountId);
+  const teamMembers = $derived(agentsStore.sortedAgents);
+  const isLoading = $derived(agentsStore.isLoading);
+  const error = $derived(agentsStore.error);
+
   const filteredMembers = $derived(() => {
     if (!searchQuery.trim()) return teamMembers;
     const query = searchQuery.toLowerCase();
@@ -66,7 +35,6 @@
     );
   });
 
-  // Get initials from name
   function getInitials(name: string): string {
     return name
       .split(' ')
@@ -76,66 +44,24 @@
       .slice(0, 2);
   }
 
-  // Get role badge variant
   function getRoleBadgeVariant(
     role: string
   ): 'default' | 'secondary' | 'outline' {
-    switch (role) {
-      case 'Admin':
-        return 'default';
-      case 'Agent':
-        return 'secondary';
-      default:
-        return 'outline';
-    }
+    return role === 'administrator' ? 'default' : 'secondary';
   }
 
-  // Get role color class
-  function getRoleColorClass(role: string): string {
-    switch (role) {
-      case 'Admin':
-        return 'border-l-4 border-l-purple-500';
-      case 'Agent':
-        return 'border-l-4 border-l-blue-500';
-      default:
-        return 'border-l-4 border-l-gray-300';
-    }
-  }
-
-  // Get availability badge variant
   function getAvailabilityVariant(
     availability: string
   ): 'default' | 'secondary' | 'outline' {
-    switch (availability) {
-      case 'Online':
-        return 'default';
-      case 'Away':
-        return 'secondary';
-      default:
-        return 'outline';
-    }
+    return availability === 'online' ? 'default' : 'outline';
   }
 
-  // Get availability color
-  function getAvailabilityColor(availability: string): string {
-    switch (availability) {
-      case 'Online':
-        return 'bg-green-500';
-      case 'Away':
-        return 'bg-yellow-500';
-      default:
-        return 'bg-gray-400';
-    }
-  }
-
-  onMount(() => {
-    // TODO: Fetch team members from teamsStore
-    // teamsStore.fetchTeamMembers();
+  onMount(async () => {
+    await agentsStore.fetchAgents({ page: 1 });
   });
 </script>
 
 <div class="container mx-auto p-6">
-  <!-- Header -->
   <div
     class="mb-6 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between"
   >
@@ -145,13 +71,12 @@
         Manage your team members and their roles
       </p>
     </div>
-    <Button>
+    <Button onclick={() => goto(`/app/accounts/${accountId}/settings/agents`)}>
       <UserPlus class="mr-2 h-4 w-4" />
       Add Team Member
     </Button>
   </div>
 
-  <!-- Search -->
   <div class="mb-6">
     <div class="relative">
       <Search
@@ -166,7 +91,6 @@
     </div>
   </div>
 
-  <!-- Team count -->
   <div class="mb-4">
     <p class="text-sm text-muted-foreground">
       {filteredMembers().length}
@@ -174,88 +98,61 @@
     </p>
   </div>
 
-  <!-- Loading state -->
   {#if isLoading}
     <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
       {#each Array(6) as _}
-        <Card.Root>
-          <Card.Content class="p-6">
-            <div class="flex items-start gap-4">
-              <Skeleton class="h-12 w-12 rounded-full" />
-              <div class="flex-1 space-y-2">
-                <Skeleton class="h-4 w-32" />
-                <Skeleton class="h-3 w-48" />
-                <Skeleton class="h-6 w-20" />
-              </div>
-            </div>
-          </Card.Content>
-        </Card.Root>
+        <Card.Root
+          ><Card.Content class="p-6"
+            ><Skeleton class="h-24 w-full" /></Card.Content
+          ></Card.Root
+        >
       {/each}
     </div>
+  {:else if error}
+    <Card.Root>
+      <Card.Content class="flex flex-col items-center justify-center py-12">
+        <AlertCircle class="mb-4 h-12 w-12 text-destructive" />
+        <h3 class="mb-2 text-lg font-semibold">Unable to load team members</h3>
+        <p class="mb-4 text-sm text-muted-foreground">{error}</p>
+        <Button
+          variant="outline"
+          onclick={() => agentsStore.fetchAgents({ page: 1 })}>Retry</Button
+        >
+      </Card.Content>
+    </Card.Root>
   {:else if filteredMembers().length === 0}
-    <!-- Empty state -->
     <Card.Root>
       <Card.Content class="flex flex-col items-center justify-center py-12">
         <UserCheck class="mb-4 h-12 w-12 text-muted-foreground" />
-        <h3 class="mb-2 text-lg font-semibold">
-          {searchQuery ? 'No team members found' : 'No team members yet'}
-        </h3>
-        <p class="mb-4 text-center text-sm text-muted-foreground">
-          {searchQuery
-            ? 'Try adjusting your search query'
-            : 'Get started by inviting team members to your workspace'}
-        </p>
-        {#if !searchQuery}
-          <Button>
-            <UserPlus class="mr-2 h-4 w-4" />
-            Invite Team Member
-          </Button>
-        {/if}
+        <h3 class="mb-2 text-lg font-semibold">No team members found</h3>
       </Card.Content>
     </Card.Root>
   {:else}
-    <!-- Team members grid -->
     <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
       {#each filteredMembers() as member (member.id)}
-        <Card.Root
-          class="transition-shadow hover:shadow-md {getRoleColorClass(
-            member.role
-          )}"
-        >
+        <Card.Root class="transition-shadow hover:shadow-md">
           <Card.Content class="p-6">
             <div class="flex items-start gap-4">
-              <!-- Avatar -->
               <Avatar.Root class="h-12 w-12">
-                {#if member.avatar}
-                  <Avatar.Image src={member.avatar} alt={member.name} />
+                {#if member.avatarUrl}
+                  <Avatar.Image src={member.avatarUrl} alt={member.name} />
                 {/if}
                 <Avatar.Fallback>{getInitials(member.name)}</Avatar.Fallback>
               </Avatar.Root>
 
-              <!-- Member info -->
               <div class="flex-1 min-w-0">
-                <div class="mb-1 flex items-center gap-2">
-                  <h3 class="truncate font-semibold">{member.name}</h3>
-                  <div
-                    class="h-2 w-2 rounded-full {getAvailabilityColor(
-                      member.availability
-                    )}"
-                  ></div>
-                </div>
+                <h3 class="truncate font-semibold">{member.name}</h3>
                 <div
                   class="mb-2 flex items-center gap-1 text-sm text-muted-foreground"
                 >
                   <Mail class="h-3 w-3" />
                   <a
                     href="mailto:{member.email}"
-                    class="truncate hover:underline"
+                    class="truncate hover:underline">{member.email}</a
                   >
-                    {member.email}
-                  </a>
                 </div>
 
-                <!-- Role and status badges -->
-                <div class="mb-3 flex flex-wrap gap-2">
+                <div class="flex flex-wrap gap-2">
                   <Badge
                     variant={getRoleBadgeVariant(member.role)}
                     class="gap-1"
@@ -263,21 +160,11 @@
                     <Shield class="h-3 w-3" />
                     {member.role}
                   </Badge>
-                  <Badge variant={getAvailabilityVariant(member.availability)}>
-                    {member.availability}
+                  <Badge
+                    variant={getAvailabilityVariant(member.availabilityStatus)}
+                  >
+                    {member.availabilityStatus}
                   </Badge>
-                </div>
-
-                <!-- Actions -->
-                <div class="flex gap-2">
-                  <Button variant="outline" size="sm">
-                    <Edit class="mr-1 h-3 w-3" />
-                    Edit
-                  </Button>
-                  <Button variant="outline" size="sm">
-                    <Trash2 class="mr-1 h-3 w-3" />
-                    Remove
-                  </Button>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
### Motivation
- Replace placeholder UI/data on account-scoped pages with real store- and API-backed flows to make pages functional and account-aware.
- Align frontend requests/response shapes with the Laravel backend (account-scoped search endpoint, Laravel paginator `meta`, and `search` query param) to avoid mismatches.
- Provide a safe interim billing UI by deriving a minimal plan summary from existing account details until dedicated billing endpoints exist.

### Description
- Added/updated API clients: `src/lib/api/cannedResponses.ts`, `src/lib/api/integrations.ts`, `src/lib/api/billing.ts`, and extended `src/lib/api/accounts.ts` with `show()`; updated `src/lib/api/search.ts` to be account-scoped (`/api/v1/accounts/:accountId/search`).
- Introduced stores for the new flows: `cannedResponses`, `integrations`, `billing`, and updated `search` store to derive `accountId` from `$page.params`; stores expose loading/error/pagination state and actions. 
- Wired account pages to stores and UX patterns: updated `src/routes/app/accounts/[accountId]/team/+page.svelte`, `.../search/+page.svelte`, `.../integrations/+page.svelte`, `.../canned-responses/+page.svelte`, and `.../settings/billing/+page.svelte` to use store state, toasts, confirmation dialogs, and pagination controls; mapped backend `enabled` → UI `status` where applicable.
- Formatted touched TypeScript/Svelte files and resolved Prettier parser issues for Svelte files by explicitly supplying the `prettier-plugin-svelte` plugin path during formatting.

### Testing
- Ran `composer install` in `laravel-svelte-port/laravel` successfully. ✅
- Started Laravel with `php artisan serve` and Svelte dev server with `pnpm run dev`, then executed a Playwright script that navigated to the changed routes and produced screenshots. ✅
- Ran frontend checks with `pnpm run -s check` (`svelte-check`) which completed but surfaced a pre-existing TypeScript error in `src/lib/components/reports/shared/ReportContainer.svelte`. ⚠️
- Ran formatting (`prettier` with the Svelte plugin) on modified files and committed the formatted changes. ✅

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_698eee68c500832a82a0adba881e671c)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Billing dashboard: current plan, invoice history with download actions and upgrade/redirect flow
  * Canned responses: paginated search, copy shortcode, create/edit, delete with confirmation and toasts
  * Integrations: browse, connect/configure, status badges and quick actions
  * Account-scoped search: paginated, load-more results with refined result types and navigation
  * Team management: centralized, store-driven listing and navigation

* **Bug Fixes & Improvements**
  * Centralized client stores for billing, canned responses, integrations, search, and team pages
  * Improved loading states, error handling, retry flows and empty-state messaging
<!-- end of auto-generated comment: release notes by coderabbit.ai -->