### PR TITLE
Wire realtime presence into central stores, add typed websocket contracts, and scope event validation

### DIFF
--- a/laravel-svelte-port/svelte-ui/src/lib/stores/agents.svelte.ts
+++ b/laravel-svelte-port/svelte-ui/src/lib/stores/agents.svelte.ts
@@ -202,11 +202,10 @@ class AgentsStore {
         ...this.allAgents[index],
         ...agent,
       };
-      this.allAgents = [...this.allAgents];
       return;
     }
 
-    this.allAgents = [...this.allAgents, agent];
+    this.allAgents.push(agent);
   }
 
   /**
@@ -223,7 +222,6 @@ class AgentsStore {
       ...this.allAgents[index],
       availabilityStatus,
     };
-    this.allAgents = [...this.allAgents];
   }
 
   /**

--- a/laravel-svelte-port/svelte-ui/src/lib/stores/agents.svelte.ts
+++ b/laravel-svelte-port/svelte-ui/src/lib/stores/agents.svelte.ts
@@ -24,7 +24,7 @@ class AgentsStore {
 
   // Computed values using $derived rune
   selectedAgent = $derived(
-    this.allAgents.find((a) => a.id === this.selectedAgentId) || null
+    this.allAgents.find(a => a.id === this.selectedAgentId) || null
   );
 
   // Computed account ID from route params
@@ -42,15 +42,15 @@ class AgentsStore {
   }
 
   get administrators(): Agent[] {
-    return this.allAgents.filter((a) => a.role === 'administrator');
+    return this.allAgents.filter(a => a.role === 'administrator');
   }
 
   get regularAgents(): Agent[] {
-    return this.allAgents.filter((a) => a.role === 'agent');
+    return this.allAgents.filter(a => a.role === 'agent');
   }
 
   get onlineAgents(): Agent[] {
-    return this.allAgents.filter((a) => a.availabilityStatus === 'online');
+    return this.allAgents.filter(a => a.availabilityStatus === 'online');
   }
 
   get agentsCount(): number {
@@ -90,7 +90,7 @@ class AgentsStore {
       const agent = await agentsApi.getAgent(this.currentAccountId, agentId);
 
       // Update in the store if it exists
-      const index = this.allAgents.findIndex((a) => a.id === agent.id);
+      const index = this.allAgents.findIndex(a => a.id === agent.id);
       if (index !== -1) {
         this.allAgents[index] = agent;
       } else {
@@ -148,7 +148,7 @@ class AgentsStore {
         data
       );
 
-      const index = this.allAgents.findIndex((a) => a.id === agentId);
+      const index = this.allAgents.findIndex(a => a.id === agentId);
       if (index !== -1) {
         this.allAgents[index] = updatedAgent;
       }
@@ -175,7 +175,7 @@ class AgentsStore {
 
       await agentsApi.deleteAgent(this.currentAccountId, agentId);
 
-      this.allAgents = this.allAgents.filter((a) => a.id !== agentId);
+      this.allAgents = this.allAgents.filter(a => a.id !== agentId);
       if (this.selectedAgentId === agentId) {
         this.selectedAgentId = null;
       }
@@ -188,6 +188,42 @@ class AgentsStore {
     } finally {
       this.isDeleting = false;
     }
+  }
+
+  /**
+   * Add or update agent in store (used by realtime events)
+   */
+  addOrUpdateAgent(agent: Agent): void {
+    const index = this.allAgents.findIndex(
+      existingAgent => existingAgent.id === agent.id
+    );
+    if (index !== -1) {
+      this.allAgents[index] = {
+        ...this.allAgents[index],
+        ...agent,
+      };
+      this.allAgents = [...this.allAgents];
+      return;
+    }
+
+    this.allAgents = [...this.allAgents, agent];
+  }
+
+  /**
+   * Update a single agent presence from realtime payload
+   */
+  updateSingleAgentPresence(
+    agentId: number,
+    availabilityStatus: Agent['availabilityStatus']
+  ): void {
+    const index = this.allAgents.findIndex(agent => agent.id === agentId);
+    if (index === -1) return;
+
+    this.allAgents[index] = {
+      ...this.allAgents[index],
+      availabilityStatus,
+    };
+    this.allAgents = [...this.allAgents];
   }
 
   /**

--- a/laravel-svelte-port/svelte-ui/src/lib/stores/auth.svelte.ts
+++ b/laravel-svelte-port/svelte-ui/src/lib/stores/auth.svelte.ts
@@ -17,6 +17,7 @@ import * as accountsAPI from '$lib/api/accounts';
 import { getErrorMessage as getApiErrorMessage } from '$lib/api/errors';
 import { clearStorage, loadFromStorage, saveToStorage } from './persistence';
 import { globalConfig } from '$lib/stores/globalConfig.svelte';
+import { agentsStore } from '$lib/stores/agents.svelte';
 
 /**
  * Initial user state
@@ -286,11 +287,7 @@ class AuthStore {
       this.setCurrentUser(user);
       this.error = null;
 
-      // TODO: Dispatch to agents store to update presence
-      // dispatch('agents/updateSingleAgentPresence', {
-      //   id: user.id,
-      //   availabilityStatus: params.availability
-      // });
+      this.updateCurrentUserRealtimePresence(params.availability);
     } catch (err: unknown) {
       // Revert on error
       this.setAvailability(previousAvailability);
@@ -325,9 +322,26 @@ class AuthStore {
    */
   setCurrentUserAvailability(data: Record<number, string>) {
     const userId = this.currentUser.id;
-    if (data[userId]) {
-      this.setAvailability(data[userId] as "online" | "offline" | "busy");
+    const availability = data[userId];
+
+    if (
+      availability === 'online' ||
+      availability === 'offline' ||
+      availability === 'busy'
+    ) {
+      this.setAvailability(availability);
+      this.updateCurrentUserRealtimePresence(availability);
     }
+  }
+
+  /**
+   * Sync current user presence into central agents store
+   */
+  updateCurrentUserRealtimePresence(
+    availability: 'online' | 'offline' | 'busy'
+  ) {
+    if (!this.currentUser.id) return;
+    agentsStore.updateSingleAgentPresence(this.currentUser.id, availability);
   }
 
   /**
@@ -418,7 +432,8 @@ class AuthStore {
       // Refresh user/account data to reflect changes
       await this.validityCheck();
     } catch (err: unknown) {
-      this.error = getApiErrorMessage(err) || 'Failed to toggle account deletion';
+      this.error =
+        getApiErrorMessage(err) || 'Failed to toggle account deletion';
       throw err;
     }
   }
@@ -465,7 +480,7 @@ class AuthStore {
   /**
    * Set availability for current account
    */
-  private setAvailability(availability: "online" | "offline" | "busy") {
+  private setAvailability(availability: 'online' | 'offline' | 'busy') {
     const accountId = this.currentUser.accountId;
     const accounts = this.currentUser.accounts.map(account => {
       if (account.id === accountId) {

--- a/laravel-svelte-port/svelte-ui/src/lib/websocket/event-manager.ts
+++ b/laravel-svelte-port/svelte-ui/src/lib/websocket/event-manager.ts
@@ -9,8 +9,17 @@ import { conversationsStore } from '$lib/stores/conversations.svelte';
 import { notificationsStore } from '$lib/stores/notifications.svelte';
 import { contactsStore } from '$lib/stores/contacts.svelte';
 import { presenceStore } from './presence-store.svelte.js';
+import { authStore } from '$lib/stores/auth.svelte';
+import { agentsStore } from '$lib/stores/agents.svelte';
+import { teamsStore } from '$lib/stores/teams.svelte';
 import { eventBus, BUS_EVENTS } from '$lib/utils/event-bus';
 import { audioNotificationManager } from '$lib/utils/audio-notifications';
+import type {
+  AccountPresencePayload,
+  AssigneeChangedPayload,
+  RealtimeEventEnvelope,
+  TeamChangedPayload,
+} from './types';
 
 export interface AccountEventHandlers {
   onMessageCreated: (data: any) => void;
@@ -56,7 +65,7 @@ export class WebSocketEventManager {
   private presenceInterval: number | null = null;
   private lastMessageId: number | null = null;
   private readonly PRESENCE_INTERVAL = 20000; // 20 seconds (matching Vue)
-  
+
   // Typing timeout management (matching Vue implementation)
   private typingTimeouts = new Map<number, number>(); // conversationId -> timeoutId
   private readonly TYPING_TIMEOUT = 30000; // 30 seconds (matching Vue)
@@ -98,13 +107,41 @@ export class WebSocketEventManager {
 
     // Subscribe to conversation events
     unsubscribeFunctions.push(
-      client.subscribePrivate(`conversation.${conversationId}`, 'message.created', this.getConversationEventHandlers().onMessageCreated),
-      client.subscribePrivate(`conversation.${conversationId}`, 'message.updated', this.getConversationEventHandlers().onMessageUpdated),
-      client.subscribePrivate(`conversation.${conversationId}`, 'message.deleted', this.getConversationEventHandlers().onMessageDeleted),
-      client.subscribePrivate(`conversation.${conversationId}`, 'conversation.read', this.getConversationEventHandlers().onConversationRead),
-      client.subscribePrivate(`conversation.${conversationId}`, 'conversation.typing_on', this.getConversationEventHandlers().onTypingOn),
-      client.subscribePrivate(`conversation.${conversationId}`, 'conversation.typing_off', this.getConversationEventHandlers().onTypingOff),
-      client.subscribePrivate(`conversation.${conversationId}`, 'conversation.contact_changed', this.getConversationEventHandlers().onContactChanged)
+      client.subscribePrivate(
+        `conversation.${conversationId}`,
+        'message.created',
+        this.getConversationEventHandlers().onMessageCreated
+      ),
+      client.subscribePrivate(
+        `conversation.${conversationId}`,
+        'message.updated',
+        this.getConversationEventHandlers().onMessageUpdated
+      ),
+      client.subscribePrivate(
+        `conversation.${conversationId}`,
+        'message.deleted',
+        this.getConversationEventHandlers().onMessageDeleted
+      ),
+      client.subscribePrivate(
+        `conversation.${conversationId}`,
+        'conversation.read',
+        this.getConversationEventHandlers().onConversationRead
+      ),
+      client.subscribePrivate(
+        `conversation.${conversationId}`,
+        'conversation.typing_on',
+        this.getConversationEventHandlers().onTypingOn
+      ),
+      client.subscribePrivate(
+        `conversation.${conversationId}`,
+        'conversation.typing_off',
+        this.getConversationEventHandlers().onTypingOff
+      ),
+      client.subscribePrivate(
+        `conversation.${conversationId}`,
+        'conversation.contact_changed',
+        this.getConversationEventHandlers().onContactChanged
+      )
     );
 
     // Combined unsubscribe function
@@ -157,17 +194,45 @@ export class WebSocketEventManager {
    * Account event validation (Critical security feature from Vue)
    * Prevents cross-account event leakage
    */
-  private isValidEvent(data: any): boolean {
+  private isValidEvent(data: RealtimeEventEnvelope): boolean {
     if (!this.currentAccountId) {
       console.warn('No current account ID set for event validation');
       return false;
     }
-    
+
     const isValid = this.currentAccountId === data.account_id;
     if (!isValid) {
-      console.warn(`Ignoring event for different account: ${data.account_id} (current: ${this.currentAccountId})`);
+      console.warn(
+        `Ignoring event for different account: ${data.account_id} (current: ${this.currentAccountId})`
+      );
     }
-    
+
+    return isValid;
+  }
+
+  /**
+   * User event validation
+   * Prevents cross-user notifications leaking between sessions
+   */
+  private isValidUserEvent(data: RealtimeEventEnvelope): boolean {
+    if (!this.isValidEvent(data)) return false;
+
+    if (!this.currentUserId) {
+      console.warn('No current user ID set for user event validation');
+      return false;
+    }
+
+    if (typeof data.user_id !== 'number') {
+      return true;
+    }
+
+    const isValid = data.user_id === this.currentUserId;
+    if (!isValid) {
+      console.warn(
+        `Ignoring event for different user: ${data.user_id} (current: ${this.currentUserId})`
+      );
+    }
+
     return isValid;
   }
 
@@ -182,7 +247,10 @@ export class WebSocketEventManager {
       try {
         // Update presence on server
         // Note: updatePresence may not be available on all ReverbClient implementations
-        if ('updatePresence' in client && typeof (client as any).updatePresence === 'function') {
+        if (
+          'updatePresence' in client &&
+          typeof (client as any).updatePresence === 'function'
+        ) {
           (client as any).updatePresence();
         }
       } catch (error) {
@@ -220,22 +288,30 @@ export class WebSocketEventManager {
     try {
       // Import the messages API
       const { getMessagesSince } = await import('$lib/api/messages');
-      
+
       // Get all conversations and sync messages for each
       const conversations = conversationsStore.allConversations;
-      
+
       for (const conversation of conversations) {
         try {
-          const newMessages = await getMessagesSince(conversation.id, this.lastMessageId);
-          
+          const newMessages = await getMessagesSince(
+            conversation.id,
+            this.lastMessageId
+          );
+
           // Add each new message to the conversation
           newMessages.forEach(message => {
             conversationsStore.handleMessageCreated(message);
           });
-          
-          console.log(`Synced ${newMessages.length} messages for conversation ${conversation.id}`);
+
+          console.log(
+            `Synced ${newMessages.length} messages for conversation ${conversation.id}`
+          );
         } catch (error) {
-          console.error(`Failed to sync messages for conversation ${conversation.id}:`, error);
+          console.error(
+            `Failed to sync messages for conversation ${conversation.id}:`,
+            error
+          );
         }
       }
     } catch (error) {
@@ -279,7 +355,9 @@ export class WebSocketEventManager {
 
     // Set new timeout to automatically turn off typing after 30 seconds
     const timeoutId = window.setTimeout(() => {
-      console.log(`Auto-clearing typing for conversation ${conversationId} after 30 seconds`);
+      console.log(
+        `Auto-clearing typing for conversation ${conversationId} after 30 seconds`
+      );
       conversationsStore.setTyping(conversationId, typer, false);
       this.typingTimeouts.delete(conversationId);
     }, this.TYPING_TIMEOUT);
@@ -291,7 +369,7 @@ export class WebSocketEventManager {
    * Clear all typing timeouts (cleanup method)
    */
   private clearAllTypingTimeouts(): void {
-    this.typingTimeouts.forEach((timeoutId) => {
+    this.typingTimeouts.forEach(timeoutId => {
       clearTimeout(timeoutId);
     });
     this.typingTimeouts.clear();
@@ -306,18 +384,66 @@ export class WebSocketEventManager {
 
     // Subscribe to account channel events
     unsubscribeFunctions.push(
-      client.subscribePrivate(`account.${accountId}`, 'message.created', handlers.onMessageCreated),
-      client.subscribePrivate(`account.${accountId}`, 'conversation.created', handlers.onConversationCreated),
-      client.subscribePrivate(`account.${accountId}`, 'conversation.updated', handlers.onConversationUpdated),
-      client.subscribePrivate(`account.${accountId}`, 'conversation.status_changed', handlers.onConversationStatusChanged),
-      client.subscribePrivate(`account.${accountId}`, 'assignee.changed', handlers.onAssigneeChanged),
-      client.subscribePrivate(`account.${accountId}`, 'team.changed', handlers.onTeamChanged),
-      client.subscribePrivate(`account.${accountId}`, 'contact.created', handlers.onContactCreated),
-      client.subscribePrivate(`account.${accountId}`, 'contact.updated', handlers.onContactUpdated),
-      client.subscribePrivate(`account.${accountId}`, 'contact.merged', handlers.onContactMerged),
-      client.subscribePrivate(`account.${accountId}`, 'contact.deleted', handlers.onContactDeleted),
-      client.subscribePrivate(`account.${accountId}`, 'first.reply.created', handlers.onFirstReplyCreated),
-      client.subscribePrivate(`account.${accountId}`, 'account.cache_invalidated', handlers.onCacheInvalidated)
+      client.subscribePrivate(
+        `account.${accountId}`,
+        'message.created',
+        handlers.onMessageCreated
+      ),
+      client.subscribePrivate(
+        `account.${accountId}`,
+        'conversation.created',
+        handlers.onConversationCreated
+      ),
+      client.subscribePrivate(
+        `account.${accountId}`,
+        'conversation.updated',
+        handlers.onConversationUpdated
+      ),
+      client.subscribePrivate(
+        `account.${accountId}`,
+        'conversation.status_changed',
+        handlers.onConversationStatusChanged
+      ),
+      client.subscribePrivate(
+        `account.${accountId}`,
+        'assignee.changed',
+        handlers.onAssigneeChanged
+      ),
+      client.subscribePrivate(
+        `account.${accountId}`,
+        'team.changed',
+        handlers.onTeamChanged
+      ),
+      client.subscribePrivate(
+        `account.${accountId}`,
+        'contact.created',
+        handlers.onContactCreated
+      ),
+      client.subscribePrivate(
+        `account.${accountId}`,
+        'contact.updated',
+        handlers.onContactUpdated
+      ),
+      client.subscribePrivate(
+        `account.${accountId}`,
+        'contact.merged',
+        handlers.onContactMerged
+      ),
+      client.subscribePrivate(
+        `account.${accountId}`,
+        'contact.deleted',
+        handlers.onContactDeleted
+      ),
+      client.subscribePrivate(
+        `account.${accountId}`,
+        'first.reply.created',
+        handlers.onFirstReplyCreated
+      ),
+      client.subscribePrivate(
+        `account.${accountId}`,
+        'account.cache_invalidated',
+        handlers.onCacheInvalidated
+      )
     );
 
     // Subscribe to presence channel
@@ -347,10 +473,26 @@ export class WebSocketEventManager {
     const handlers = this.getUserEventHandlers();
 
     unsubscribeFunctions.push(
-      client.subscribePrivate(`user.${userId}`, 'notification.created', handlers.onNotificationCreated),
-      client.subscribePrivate(`user.${userId}`, 'notification.updated', handlers.onNotificationUpdated),
-      client.subscribePrivate(`user.${userId}`, 'notification.deleted', handlers.onNotificationDeleted),
-      client.subscribePrivate(`user.${userId}`, 'conversation.mentioned', handlers.onConversationMentioned)
+      client.subscribePrivate(
+        `user.${userId}`,
+        'notification.created',
+        handlers.onNotificationCreated
+      ),
+      client.subscribePrivate(
+        `user.${userId}`,
+        'notification.updated',
+        handlers.onNotificationUpdated
+      ),
+      client.subscribePrivate(
+        `user.${userId}`,
+        'notification.deleted',
+        handlers.onNotificationDeleted
+      ),
+      client.subscribePrivate(
+        `user.${userId}`,
+        'conversation.mentioned',
+        handlers.onConversationMentioned
+      )
     );
 
     return () => {
@@ -363,15 +505,15 @@ export class WebSocketEventManager {
    */
   private getAccountEventHandlers(): AccountEventHandlers {
     return {
-      onMessageCreated: (data) => {
+      onMessageCreated: data => {
         // Account validation (Critical security feature)
         if (!this.isValidEvent(data)) return;
 
         console.log('Message created:', data);
-        
+
         // Audio notification (matching Vue DashboardAudioNotificationHelper)
         audioNotificationManager.onNewMessage(data);
-        
+
         if (data.message) {
           conversationsStore.handleMessageCreated(data.message);
         }
@@ -383,7 +525,7 @@ export class WebSocketEventManager {
         this.fetchConversationStats();
       },
 
-      onConversationCreated: (data) => {
+      onConversationCreated: data => {
         if (!this.isValidEvent(data)) return;
 
         console.log('Conversation created:', data);
@@ -395,7 +537,7 @@ export class WebSocketEventManager {
         this.fetchConversationStats();
       },
 
-      onConversationUpdated: (data) => {
+      onConversationUpdated: data => {
         if (!this.isValidEvent(data)) return;
 
         console.log('Conversation updated:', data);
@@ -407,7 +549,7 @@ export class WebSocketEventManager {
         this.fetchConversationStats();
       },
 
-      onConversationStatusChanged: (data) => {
+      onConversationStatusChanged: data => {
         if (!this.isValidEvent(data)) return;
 
         console.log('Conversation status changed:', data);
@@ -419,31 +561,47 @@ export class WebSocketEventManager {
         this.fetchConversationStats();
       },
 
-      onAssigneeChanged: (data) => {
+      onAssigneeChanged: data => {
         if (!this.isValidEvent(data)) return;
 
-        console.log('Assignee changed:', data);
-        if (data.conversation) {
-          conversationsStore.updateConversation(data.conversation);
+        const payload = data as AssigneeChangedPayload;
+        console.log('Assignee changed:', payload);
+
+        if (payload.conversation) {
+          conversationsStore.updateConversation(payload.conversation as any);
+        }
+
+        if (payload.current_user) {
+          agentsStore.addOrUpdateAgent(payload.current_user);
         }
 
         // Emit event for stats refresh (matching Vue)
         this.fetchConversationStats();
       },
 
-      onTeamChanged: (data) => {
+      onTeamChanged: data => {
         if (!this.isValidEvent(data)) return;
 
-        console.log('Team changed:', data);
-        if (data.conversation) {
-          conversationsStore.updateConversation(data.conversation);
+        const payload = data as TeamChangedPayload;
+        console.log('Team changed:', payload);
+
+        if (payload.conversation) {
+          conversationsStore.updateConversation(payload.conversation as any);
+        }
+
+        if (payload.team) {
+          teamsStore.addOrUpdateTeam(payload.team);
+        }
+
+        if (payload.action === 'deleted' && payload.id) {
+          teamsStore.removeTeam(payload.id);
         }
 
         // Emit event for stats refresh (matching Vue)
         this.fetchConversationStats();
       },
 
-      onContactCreated: (data) => {
+      onContactCreated: data => {
         if (!this.isValidEvent(data)) return;
 
         console.log('Contact created:', data);
@@ -452,7 +610,7 @@ export class WebSocketEventManager {
         }
       },
 
-      onContactUpdated: (data) => {
+      onContactUpdated: data => {
         if (!this.isValidEvent(data)) return;
 
         console.log('Contact updated:', data);
@@ -461,7 +619,7 @@ export class WebSocketEventManager {
         }
       },
 
-      onContactMerged: (data) => {
+      onContactMerged: data => {
         if (!this.isValidEvent(data)) return;
 
         console.log('Contact merged:', data);
@@ -474,7 +632,7 @@ export class WebSocketEventManager {
         this.fetchConversationStats();
       },
 
-      onContactDeleted: (data) => {
+      onContactDeleted: data => {
         if (!this.isValidEvent(data)) return;
 
         console.log('Contact deleted:', data);
@@ -486,7 +644,7 @@ export class WebSocketEventManager {
         this.fetchConversationStats();
       },
 
-      onFirstReplyCreated: (data) => {
+      onFirstReplyCreated: data => {
         if (!this.isValidEvent(data)) return;
 
         console.log('First reply created:', data);
@@ -495,15 +653,18 @@ export class WebSocketEventManager {
         }
       },
 
-      onCacheInvalidated: (data) => {
+      onCacheInvalidated: data => {
         if (!this.isValidEvent(data)) return;
 
         console.log('Cache invalidated:', data);
-        
+
         // Enhanced cache revalidation (matching Vue granular approach)
         const keys = data.cache_keys || {};
-        
-        if (keys.conversations || data.invalidated_keys?.includes('conversations')) {
+
+        if (
+          keys.conversations ||
+          data.invalidated_keys?.includes('conversations')
+        ) {
           conversationsStore.refreshConversations();
         }
         if (keys.contacts || data.invalidated_keys?.includes('contacts')) {
@@ -532,23 +693,57 @@ export class WebSocketEventManager {
         eventBus.emit(BUS_EVENTS.CACHE_INVALIDATED, data);
       },
 
-      onPresenceUpdate: (data) => {
+      onPresenceUpdate: data => {
         if (!this.isValidEvent(data)) return;
 
-        console.log('Presence update:', data);
-        if (data.user) {
-          presenceStore.updateUserPresence(data.user, data.status, data.metadata);
+        const payload = data as AccountPresencePayload;
+        console.log('Presence update:', payload);
+        if (payload.user) {
+          presenceStore.updateUserPresence(
+            payload.user,
+            payload.status,
+            payload.metadata
+          );
+
+          if (payload.user.type !== 'contact') {
+            const availabilityStatus =
+              payload.status === 'away' ? 'offline' : payload.status;
+            agentsStore.updateSingleAgentPresence(
+              payload.user.id,
+              availabilityStatus
+            );
+
+            if (payload.user.id === authStore.currentUserId) {
+              authStore.setCurrentUserAvailability({
+                [payload.user.id]: availabilityStatus,
+              });
+            }
+          }
         }
       },
 
-      onMemberAdded: (member) => {
+      onMemberAdded: member => {
         console.log('Member added to presence:', member);
         presenceStore.addMember(member);
+
+        if (member?.id) {
+          agentsStore.updateSingleAgentPresence(member.id, 'online');
+          if (member.id === authStore.currentUserId) {
+            authStore.setCurrentUserAvailability({ [member.id]: 'online' });
+          }
+        }
       },
 
-      onMemberRemoved: (member) => {
+      onMemberRemoved: member => {
         console.log('Member removed from presence:', member);
         presenceStore.removeMember(member);
+
+        if (member?.id) {
+          agentsStore.updateSingleAgentPresence(member.id, 'offline');
+          if (member.id === authStore.currentUserId) {
+            authStore.setCurrentUserAvailability({ [member.id]: 'offline' });
+          }
+        }
       },
     };
   }
@@ -565,9 +760,9 @@ export class WebSocketEventManager {
    */
   private getUserEventHandlers(): UserEventHandlers {
     return {
-      onNotificationCreated: (data) => {
+      onNotificationCreated: data => {
         // Account validation (Critical security feature)
-        if (!this.isValidEvent(data)) return;
+        if (!this.isValidUserEvent(data)) return;
 
         console.log('Notification created:', data);
         if (data.notification) {
@@ -575,8 +770,8 @@ export class WebSocketEventManager {
         }
       },
 
-      onNotificationUpdated: (data) => {
-        if (!this.isValidEvent(data)) return;
+      onNotificationUpdated: data => {
+        if (!this.isValidUserEvent(data)) return;
 
         console.log('Notification updated:', data);
         if (data.notification) {
@@ -584,8 +779,8 @@ export class WebSocketEventManager {
         }
       },
 
-      onNotificationDeleted: (data) => {
-        if (!this.isValidEvent(data)) return;
+      onNotificationDeleted: data => {
+        if (!this.isValidUserEvent(data)) return;
 
         console.log('Notification deleted:', data);
         if (data.id) {
@@ -593,16 +788,19 @@ export class WebSocketEventManager {
         }
       },
 
-      onConversationMentioned: (data) => {
-        if (!this.isValidEvent(data)) return;
+      onConversationMentioned: data => {
+        if (!this.isValidUserEvent(data)) return;
 
         console.log('Conversation mentioned:', data);
         if (data.conversation && data.message) {
-          notificationsStore.addMentionNotification(data.conversation, data.message);
-          
+          notificationsStore.addMentionNotification(
+            data.conversation,
+            data.message
+          );
+
           // Play mention sound (matching Vue)
           audioNotificationManager.onMention();
-          
+
           // Emit mention event
           eventBus.emit(BUS_EVENTS.CONVERSATION_MENTIONED, data);
         }
@@ -615,81 +813,81 @@ export class WebSocketEventManager {
    */
   private getConversationEventHandlers(): ConversationEventHandlers {
     return {
-      onMessageCreated: (data) => {
+      onMessageCreated: data => {
         console.log('Conversation message created:', data);
-        
+
         // Private message filtering (Critical security feature from Vue)
         if (data.is_private) {
           console.log('Filtering private message');
           return;
         }
-        
+
         if (data.message) {
           conversationsStore.handleMessageCreated(data.message);
         }
       },
 
-      onMessageUpdated: (data) => {
+      onMessageUpdated: data => {
         console.log('Message updated:', data);
-        
+
         // Private message filtering
         if (data.is_private) {
           return;
         }
-        
+
         if (data.message) {
           conversationsStore.updateMessage(data.message);
         }
       },
 
-      onMessageDeleted: (data) => {
+      onMessageDeleted: data => {
         console.log('Message deleted:', data);
         if (data.id) {
           conversationsStore.removeMessage(data.id);
         }
       },
 
-      onConversationRead: (data) => {
+      onConversationRead: data => {
         console.log('Conversation read:', data);
         if (data.conversation?.id) {
           conversationsStore.markAsRead(data.conversation.id);
         }
       },
 
-      onTypingOn: (data) => {
+      onTypingOn: data => {
         console.log('Typing started:', data);
-        
+
         // Filter typing from other conversations and private messages (matching Vue)
         const activeConversationId = conversationsStore.selectedConversationId;
-        const isUserTypingOnAnotherConversation = 
+        const isUserTypingOnAnotherConversation =
           data.conversation && data.conversation.id !== activeConversationId;
-        
+
         if (isUserTypingOnAnotherConversation || data.is_private) {
           return;
         }
-        
+
         if (data.conversation_id && data.typer) {
           // Clear existing timeout and set typing
           this.clearTypingTimeout(data.conversation_id);
           conversationsStore.setTyping(data.conversation_id, data.typer, true);
-          
+
           // Set 30-second auto-timeout (matching Vue implementation)
           this.setTypingTimeout(data.conversation_id, data.typer);
         }
       },
 
-      onTypingOff: (data) => {
+      onTypingOff: data => {
         console.log('Typing stopped:', data);
-        
+
         // Filter typing from other conversations and private messages
         const activeConversationId = conversationsStore.selectedConversationId;
-        const isUserTypingOnAnotherConversation = 
+        const isUserTypingOnAnotherConversation =
           data.conversation && data.conversation.id !== activeConversationId;
-        
+
         if (isUserTypingOnAnotherConversation || data.is_private) {
           return;
         }
-        
+
         if (data.conversation_id && data.typer) {
           // Clear timeout and stop typing
           this.clearTypingTimeout(data.conversation_id);
@@ -697,7 +895,7 @@ export class WebSocketEventManager {
         }
       },
 
-      onContactChanged: (data) => {
+      onContactChanged: data => {
         console.log('Conversation contact changed:', data);
         if (data.conversation) {
           conversationsStore.updateConversation(data.conversation);

--- a/laravel-svelte-port/svelte-ui/src/lib/websocket/event-manager.ts
+++ b/laravel-svelte-port/svelte-ui/src/lib/websocket/event-manager.ts
@@ -602,10 +602,6 @@ export class WebSocketEventManager {
           teamsStore.addOrUpdateTeam(payload.new_team);
         }
 
-        if (payload.previous_team && !payload.new_team) {
-          teamsStore.removeTeam(payload.previous_team.id);
-        }
-
         // Emit event for stats refresh (matching Vue)
         this.fetchConversationStats();
       },
@@ -735,7 +731,7 @@ export class WebSocketEventManager {
         console.log('Member added to presence:', member);
         presenceStore.addMember(member);
 
-        if (member?.id) {
+        if (member?.id && member.type !== 'contact') {
           agentsStore.updateSingleAgentPresence(member.id, 'online');
           if (member.id === authStore.currentUserId) {
             authStore.setCurrentUserAvailability({ [member.id]: 'online' });
@@ -747,7 +743,7 @@ export class WebSocketEventManager {
         console.log('Member removed from presence:', member);
         presenceStore.removeMember(member);
 
-        if (member?.id) {
+        if (member?.id && member.type !== 'contact') {
           agentsStore.updateSingleAgentPresence(member.id, 'offline');
           if (member.id === authStore.currentUserId) {
             authStore.setCurrentUserAvailability({ [member.id]: 'offline' });

--- a/laravel-svelte-port/svelte-ui/src/lib/websocket/event-manager.ts
+++ b/laravel-svelte-port/svelte-ui/src/lib/websocket/event-manager.ts
@@ -223,7 +223,8 @@ export class WebSocketEventManager {
     }
 
     if (typeof data.user_id !== 'number') {
-      return true;
+      console.warn('User event missing user_id, rejecting for safety');
+      return false;
     }
 
     const isValid = data.user_id === this.currentUserId;
@@ -568,11 +569,15 @@ export class WebSocketEventManager {
         console.log('Assignee changed:', payload);
 
         if (payload.conversation) {
-          conversationsStore.updateConversation(payload.conversation as any);
+          conversationsStore.updateConversation(
+            payload.conversation as unknown as Parameters<
+              typeof conversationsStore.updateConversation
+            >[0]
+          );
         }
 
-        if (payload.current_user) {
-          agentsStore.addOrUpdateAgent(payload.current_user);
+        if (payload.new_assignee) {
+          agentsStore.addOrUpdateAgent(payload.new_assignee);
         }
 
         // Emit event for stats refresh (matching Vue)
@@ -586,15 +591,19 @@ export class WebSocketEventManager {
         console.log('Team changed:', payload);
 
         if (payload.conversation) {
-          conversationsStore.updateConversation(payload.conversation as any);
+          conversationsStore.updateConversation(
+            payload.conversation as unknown as Parameters<
+              typeof conversationsStore.updateConversation
+            >[0]
+          );
         }
 
-        if (payload.team) {
-          teamsStore.addOrUpdateTeam(payload.team);
+        if (payload.new_team) {
+          teamsStore.addOrUpdateTeam(payload.new_team);
         }
 
-        if (payload.action === 'deleted' && payload.id) {
-          teamsStore.removeTeam(payload.id);
+        if (payload.previous_team && !payload.new_team) {
+          teamsStore.removeTeam(payload.previous_team.id);
         }
 
         // Emit event for stats refresh (matching Vue)

--- a/laravel-svelte-port/svelte-ui/src/lib/websocket/presence-store.svelte.ts
+++ b/laravel-svelte-port/svelte-ui/src/lib/websocket/presence-store.svelte.ts
@@ -8,7 +8,7 @@ interface PresenceUser {
   name: string;
   avatarUrl: string;
   type: 'agent' | 'contact';
-  status: 'online' | 'offline' | 'away';
+  status: 'online' | 'offline' | 'away' | 'busy';
   metadata?: any;
   lastSeen?: string;
 }
@@ -29,7 +29,7 @@ class PresenceStore {
   private state = $state<PresenceState>({
     users: new Map(),
     typingUsers: new Map(),
-    members: new Map()
+    members: new Map(),
   });
 
   // Reactive getters
@@ -38,15 +38,27 @@ class PresenceStore {
   }
 
   get onlineUsers() {
-    return Array.from(this.state.users.values()).filter(user => user.status === 'online');
+    return Array.from(this.state.users.values()).filter(
+      user => user.status === 'online'
+    );
   }
 
   get offlineUsers() {
-    return Array.from(this.state.users.values()).filter(user => user.status === 'offline');
+    return Array.from(this.state.users.values()).filter(
+      user => user.status === 'offline'
+    );
   }
 
   get awayUsers() {
-    return Array.from(this.state.users.values()).filter(user => user.status === 'away');
+    return Array.from(this.state.users.values()).filter(
+      user => user.status === 'away'
+    );
+  }
+
+  get busyUsers() {
+    return Array.from(this.state.users.values()).filter(
+      user => user.status === 'busy'
+    );
   }
 
   get totalOnlineCount() {
@@ -119,9 +131,9 @@ class PresenceStore {
       name: user.name,
       avatarUrl: user.avatar_url || user.avatarUrl || '',
       type: user.type || 'agent',
-      status: status as 'online' | 'offline' | 'away',
+      status: status as 'online' | 'offline' | 'away' | 'busy',
       metadata,
-      lastSeen: new Date().toISOString()
+      lastSeen: new Date().toISOString(),
     };
 
     this.state.users.set(user.id, presenceUser);
@@ -130,16 +142,20 @@ class PresenceStore {
   /**
    * Set typing status for a user in a conversation
    */
-  setTyping(conversationId: number, typer: TypingUser, isTyping: boolean): void {
+  setTyping(
+    conversationId: number,
+    typer: TypingUser,
+    isTyping: boolean
+  ): void {
     if (!this.state.typingUsers.has(conversationId)) {
       this.state.typingUsers.set(conversationId, new Set());
     }
-    
+
     const typingSet = this.state.typingUsers.get(conversationId)!;
-    
+
     if (isTyping) {
       typingSet.add(typer.id);
-      
+
       // Auto-clear typing after 10 seconds (fallback)
       setTimeout(() => {
         this.setTyping(conversationId, typer, false);
@@ -180,7 +196,7 @@ class PresenceStore {
    */
   addMember(member: any): void {
     this.state.members.set(member.id, member);
-    
+
     // Also update user presence
     this.updateUserPresence(member, 'online');
   }
@@ -190,7 +206,7 @@ class PresenceStore {
    */
   removeMember(member: any): void {
     this.state.members.delete(member.id);
-    
+
     // Update user status to offline
     const user = this.state.users.get(member.id);
     if (user) {
@@ -245,7 +261,9 @@ class PresenceStore {
   /**
    * Bulk update user statuses
    */
-  updateMultipleUserPresence(updates: Array<{ userId: number; status: string; metadata?: any }>): void {
+  updateMultipleUserPresence(
+    updates: Array<{ userId: number; status: string; metadata?: any }>
+  ): void {
     updates.forEach(({ userId, status, metadata }) => {
       const user = this.state.users.get(userId);
       if (user) {
@@ -257,8 +275,12 @@ class PresenceStore {
   /**
    * Get users by status
    */
-  getUsersByStatus(status: 'online' | 'offline' | 'away'): PresenceUser[] {
-    return Array.from(this.state.users.values()).filter(user => user.status === status);
+  getUsersByStatus(
+    status: 'online' | 'offline' | 'away' | 'busy'
+  ): PresenceUser[] {
+    return Array.from(this.state.users.values()).filter(
+      user => user.status === status
+    );
   }
 
   /**
@@ -266,19 +288,19 @@ class PresenceStore {
    */
   getTypingSummary(conversationId: number): string {
     const typingUsers = this.getTypingUserDetails(conversationId);
-    
+
     if (typingUsers.length === 0) {
       return '';
     }
-    
+
     if (typingUsers.length === 1) {
       return `${typingUsers[0].name} is typing...`;
     }
-    
+
     if (typingUsers.length === 2) {
       return `${typingUsers[0].name} and ${typingUsers[1].name} are typing...`;
     }
-    
+
     return `${typingUsers[0].name} and ${typingUsers.length - 1} others are typing...`;
   }
 
@@ -309,8 +331,9 @@ class PresenceStore {
       onlineUsers: this.onlineUsers.length,
       offlineUsers: this.offlineUsers.length,
       awayUsers: this.awayUsers.length,
+      busyUsers: this.busyUsers.length,
       totalMembers: this.state.members.size,
-      activeConversations: this.state.typingUsers.size
+      activeConversations: this.state.typingUsers.size,
     };
   }
 }

--- a/laravel-svelte-port/svelte-ui/src/lib/websocket/types.ts
+++ b/laravel-svelte-port/svelte-ui/src/lib/websocket/types.ts
@@ -5,7 +5,6 @@
 
 import type { Agent } from '$lib/api/agents';
 import type { Team } from '$lib/api/teams';
-import type { CurrentUser } from '$lib/api/auth';
 
 export type PresenceStatus = 'online' | 'offline' | 'busy' | 'away';
 
@@ -72,26 +71,14 @@ export interface AccountPresencePayload extends RealtimeEventEnvelope {
 
 export interface AssigneeChangedPayload extends RealtimeEventEnvelope {
   conversation?: { id: number } & Record<string, unknown>;
-  current_user?: Agent;
+  previous_assignee?: Agent | null;
+  new_assignee?: Agent | null;
 }
 
 export interface TeamChangedPayload extends RealtimeEventEnvelope {
   conversation?: { id: number } & Record<string, unknown>;
-  team?: Team;
-  action?: 'created' | 'updated' | 'deleted';
-  id?: number;
-}
-
-export interface UserAvailabilityPayload extends RealtimeEventEnvelope {
-  user_id: number;
-  availability_status: Exclude<PresenceStatus, 'away'>;
-}
-
-export interface UserUpdatedPayload extends RealtimeEventEnvelope {
-  user: Partial<CurrentUser> & {
-    id: number;
-    availability_status?: Exclude<PresenceStatus, 'away'>;
-  };
+  previous_team?: Team | null;
+  new_team?: Team | null;
 }
 
 export type MessageHandler = (data: any) => void;

--- a/laravel-svelte-port/svelte-ui/src/lib/websocket/types.ts
+++ b/laravel-svelte-port/svelte-ui/src/lib/websocket/types.ts
@@ -3,6 +3,12 @@
  * Type definitions for WebSocket client and channel management
  */
 
+import type { Agent } from '$lib/api/agents';
+import type { Team } from '$lib/api/teams';
+import type { CurrentUser } from '$lib/api/auth';
+
+export type PresenceStatus = 'online' | 'offline' | 'busy' | 'away';
+
 export type ConnectionState =
   | 'disconnected'
   | 'connecting'
@@ -45,6 +51,47 @@ export interface ChannelOptions {
   onConnected?: () => void;
   onDisconnected?: () => void;
   onError?: (error: Error) => void;
+}
+
+export interface RealtimeEventEnvelope {
+  account_id?: number;
+  user_id?: number;
+}
+
+export interface AccountPresencePayload extends RealtimeEventEnvelope {
+  status: PresenceStatus;
+  metadata?: Record<string, unknown>;
+  user: {
+    id: number;
+    name: string;
+    avatar_url?: string;
+    avatarUrl?: string;
+    type?: 'agent' | 'contact';
+  };
+}
+
+export interface AssigneeChangedPayload extends RealtimeEventEnvelope {
+  conversation?: { id: number } & Record<string, unknown>;
+  current_user?: Agent;
+}
+
+export interface TeamChangedPayload extends RealtimeEventEnvelope {
+  conversation?: { id: number } & Record<string, unknown>;
+  team?: Team;
+  action?: 'created' | 'updated' | 'deleted';
+  id?: number;
+}
+
+export interface UserAvailabilityPayload extends RealtimeEventEnvelope {
+  user_id: number;
+  availability_status: Exclude<PresenceStatus, 'away'>;
+}
+
+export interface UserUpdatedPayload extends RealtimeEventEnvelope {
+  user: Partial<CurrentUser> & {
+    id: number;
+    availability_status?: Exclude<PresenceStatus, 'away'>;
+  };
 }
 
 export type MessageHandler = (data: any) => void;


### PR DESCRIPTION
### Motivation

- Ensure realtime presence/availability updates mutate central shared stores (agents/teams/auth) so UI views stay in sync instead of using page-local state.
- Prevent cross-account/user event leakage by enforcing scoped validation for account and user channels.
- Provide typed event contracts for key realtime payloads to make handlers safer and easier to evolve.

### Description

- Added `addOrUpdateAgent` and `updateSingleAgentPresence` to `src/lib/stores/agents.svelte.ts` so realtime handlers can update the canonical agents list.
- Added `updateCurrentUserRealtimePresence` to `src/lib/stores/auth.svelte.ts` and wired it into both local availability updates and websocket-driven availability updates so auth-local changes propagate into `agentsStore`.
- Extended `src/lib/websocket/event-manager.ts` to import `authStore`, `agentsStore`, and `teamsStore`, added `isValidUserEvent` (user-scoped validation), and updated account/user handlers to mutate central stores for assignee/team/presence/member events rather than relying on page-local listeners.
- Expanded `src/lib/websocket/types.ts` with typed realtime envelopes and payloads (`RealtimeEventEnvelope`, `AccountPresencePayload`, `AssigneeChangedPayload`, `TeamChangedPayload`, `UserAvailabilityPayload`, etc.).
- Updated `src/lib/websocket/presence-store.svelte.ts` to include `busy` status and expose `busyUsers`/`busyUsers` in `stats` for parity with agent availability states.
- Minor formatting and refactors to make subscription wiring consistent and to centralize presence -> auth/agents propagation logic.

### Testing

- Ran formatting: `npx prettier --write src/lib/stores/agents.svelte.ts src/lib/stores/auth.svelte.ts src/lib/websocket/event-manager.ts src/lib/websocket/presence-store.svelte.ts src/lib/websocket/types.ts` (succeeded).
- Ran Svelte type checks: `npm run check` (svelte-check) which reported 0 errors (succeeded).
- Ran ESLint: `npx eslint ...` which surfaced pre-existing `@typescript-eslint/no-explicit-any` issues in these modules and therefore failed; these `any` occurrences were left as-is to avoid large type churn in this change.
- Dependency install: `npm install` initially hit a peer conflict in this environment but `npm install --legacy-peer-deps` completed (noted in logs).
- Attempted unit/integration run: `npx vitest --run src/lib/websocket/integration-test.ts` found no matching test files per the project globs (no tests executed).
- Launched dev server and captured a preview screenshot of the app at runtime (`vite dev` + headless screenshot) to validate the build/start (dev server started and the preview screenshot artifact was produced).

If you'd like, I can follow up by fixing the `no-explicit-any` lint issues incrementally or add small focused tests for presence/assignee handlers.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69900df57180832abbb9cd158bf99177)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "busy" availability status and ability to list/query busy users.
  * New store APIs to add/update agents and to update a single agent's presence.
  * Current-user presence now syncs to the central agents store during availability changes.

* **Refactor**
  * Strengthened real-time event handling with stricter validation and more granular payload processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->