### PR TITLE
Localize hardcoded auth and shared UI strings in Svelte UI

### DIFF
--- a/laravel-svelte-port/svelte-ui/LOCALIZATION_REVIEW_CHECKLIST.md
+++ b/laravel-svelte-port/svelte-ui/LOCALIZATION_REVIEW_CHECKLIST.md
@@ -1,0 +1,9 @@
+# Localization Review Checklist
+
+- [ ] No new hardcoded user-visible strings in `src/routes/app/**` and `src/lib/components/**`.
+- [ ] Placeholders use `$_('...')` keys.
+- [ ] Button labels use `$_('...')` keys.
+- [ ] Status badges/tabs use `$_('...')` keys.
+- [ ] Empty states and loading labels use `$_('...')` keys.
+- [ ] New English keys are added to `src/lib/i18n/locales/en/index.json` under existing namespaces.
+- [ ] Run `pnpm check` before opening a PR.

--- a/laravel-svelte-port/svelte-ui/src/lib/components/BarChart.svelte
+++ b/laravel-svelte-port/svelte-ui/src/lib/components/BarChart.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { Chart, Svg, Axis, Bars, Highlight, Tooltip as LayerTooltip } from 'layerchart';
   import { cn } from '$lib/utils';
+  import { _ } from '$lib/i18n';
   
   interface Props {
     data: any[];
@@ -28,12 +29,12 @@
         <Bars radius={4} strokeWidth={1} />
         <Highlight area />
       </Svg>
-      <Tooltip header={(data: any) => data[xKey] || 'Unknown'}>
+      <Tooltip header={(data: any) => data[xKey] || $_('common.unknown')}>
         {#snippet children(data: any)}
           <div class="rounded-md border bg-popover p-2 text-popover-foreground shadow-md">
-            <div class="font-semibold">{data[xKey] || 'N/A'}</div>
+            <div class="font-semibold">{data[xKey] || $_('common.not_available')}</div>
             <div class="text-sm text-surface-content/50">
-              {data[yKey] != null ? data[yKey] : 'N/A'}
+              {data[yKey] != null ? data[yKey] : $_('common.not_available')}
             </div>
           </div>
         {/snippet}
@@ -41,7 +42,7 @@
     </Chart>
   {:else}
     <div class="flex items-center justify-center h-full text-muted-foreground">
-      No data available
+      {$_('common.empty.no_data_available')}
     </div>
   {/if}
 </div>

--- a/laravel-svelte-port/svelte-ui/src/lib/components/conversations/ConversationFilters.svelte
+++ b/laravel-svelte-port/svelte-ui/src/lib/components/conversations/ConversationFilters.svelte
@@ -35,12 +35,12 @@
     { value: 'resolved', label: $_('conversation.filters.status.resolved'), count: statusCounts.resolved || 0 },
   ]);
   
-  const sortOptions = [
+  const sortOptions = $derived([
     { value: 'latest', label: $_('conversation.filters.sort.latest') },
     { value: 'oldest', label: $_('conversation.filters.sort.oldest') },
     { value: 'priority', label: $_('conversation.filters.sort.priority') },
     { value: 'unread', label: $_('conversation.filters.sort.unread') },
-  ];
+  ]);
   
   let selectedStatus = $state('all');
   let selectedSort = $state('latest');

--- a/laravel-svelte-port/svelte-ui/src/lib/components/conversations/ConversationFilters.svelte
+++ b/laravel-svelte-port/svelte-ui/src/lib/components/conversations/ConversationFilters.svelte
@@ -9,6 +9,7 @@
   import { Badge } from '$lib/components/ui/badge';
   import * as Tabs from '$lib/components/ui/tabs';
   import type { ConversationFilterOptions, ConversationSortOptions } from './types';
+  import { _ } from '$lib/i18n';
   
   interface Props {
     filters?: ConversationFilterOptions;
@@ -27,18 +28,18 @@
   }: Props = $props();
   
   const statusTabs = $derived([
-    { value: 'all', label: 'All', count: statusCounts.all || 0 },
-    { value: 'mine', label: 'Mine', count: statusCounts.mine || 0 },
-    { value: 'unassigned', label: 'Unassigned', count: statusCounts.unassigned || 0 },
-    { value: 'open', label: 'Open', count: statusCounts.open || 0 },
-    { value: 'resolved', label: 'Resolved', count: statusCounts.resolved || 0 },
+    { value: 'all', label: $_('conversation.filters.status.all'), count: statusCounts.all || 0 },
+    { value: 'mine', label: $_('conversation.filters.status.mine'), count: statusCounts.mine || 0 },
+    { value: 'unassigned', label: $_('conversation.filters.status.unassigned'), count: statusCounts.unassigned || 0 },
+    { value: 'open', label: $_('conversation.filters.status.open'), count: statusCounts.open || 0 },
+    { value: 'resolved', label: $_('conversation.filters.status.resolved'), count: statusCounts.resolved || 0 },
   ]);
   
   const sortOptions = [
-    { value: 'latest', label: 'Latest' },
-    { value: 'oldest', label: 'Oldest' },
-    { value: 'priority', label: 'Priority' },
-    { value: 'unread', label: 'Unread' },
+    { value: 'latest', label: $_('conversation.filters.sort.latest') },
+    { value: 'oldest', label: $_('conversation.filters.sort.oldest') },
+    { value: 'priority', label: $_('conversation.filters.sort.priority') },
+    { value: 'unread', label: $_('conversation.filters.sort.unread') },
   ];
   
   let selectedStatus = $state('all');
@@ -46,7 +47,7 @@
   
   // Derived label for sort select display
   const sortLabel = $derived(
-    sortOptions.find(opt => opt.value === selectedSort)?.label || 'Select sort order'
+    sortOptions.find(opt => opt.value === selectedSort)?.label || $_('conversation.filters.sort.select_order')
   );
   
   // Sync selectedSort with sort prop
@@ -88,7 +89,7 @@
           <span>{tab.label}</span>
           {#if tab.count > 0}
             <Badge variant="secondary" class="text-xs">
-              {tab.count > 99 ? '99+' : tab.count}
+              {tab.count > 99 ? $_('common.badges.overflow') : tab.count}
             </Badge>
           {/if}
         </Tabs.Trigger>
@@ -98,7 +99,7 @@
   
   <!-- Sort Selector -->
   <div class="flex items-center gap-2">
-    <span class="text-sm text-muted-foreground">Sort by:</span>
+    <span class="text-sm text-muted-foreground">{$_('conversation.filters.sort_by')}</span>
     <Select.Root bind:value={selectedSort} onValueChange={handleSortChange} type="single">
       <Select.Trigger class="w-[180px]">
         {sortLabel}

--- a/laravel-svelte-port/svelte-ui/src/lib/components/notifications/NotificationList.svelte
+++ b/laravel-svelte-port/svelte-ui/src/lib/components/notifications/NotificationList.svelte
@@ -4,6 +4,7 @@
   import NotificationItem from './NotificationItem.svelte';
   import { Button } from '$lib/components/ui/button';
   import { AlertCircle, Loader2 } from '@lucide/svelte';
+  import { _ } from '$lib/i18n';
   
   interface Props {
     onNotificationOpen?: (notification: Notification) => void;
@@ -29,7 +30,7 @@
   {:else if notifications.length === 0}
     <div class="flex flex-col items-center justify-center py-12 text-center px-4">
       <AlertCircle class="h-12 w-12 text-gray-400 mb-3" />
-      <p class="text-sm text-gray-600">No notifications yet</p>
+      <p class="text-sm text-gray-600">{$_('notifications.empty_state')}</p>
     </div>
   {:else}
     <div class="divide-y">
@@ -48,7 +49,7 @@
         {#if isLoading}
           <Loader2 class="h-4 w-4 mr-2 animate-spin" />
         {/if}
-        Load more
+        {$_('notifications.load_more')}
       </Button>
     </div>
   {/if}

--- a/laravel-svelte-port/svelte-ui/src/lib/i18n/locales/en/index.json
+++ b/laravel-svelte-port/svelte-ui/src/lib/i18n/locales/en/index.json
@@ -16,7 +16,15 @@
     "export": "Export",
     "import": "Import",
     "settings": "Settings",
-    "logout": "Logout"
+    "logout": "Logout",
+    "unknown": "Unknown",
+    "not_available": "N/A",
+    "empty": {
+      "no_data_available": "No data available"
+    },
+    "badges": {
+      "overflow": "99+"
+    }
   },
   "dashboard": {
     "title": "Dashboard",
@@ -34,7 +42,24 @@
     "resolve": "Resolve",
     "reopen": "Reopen",
     "send_message": "Send message",
-    "type_message": "Type your message..."
+    "type_message": "Type your message...",
+    "filters": {
+      "sort_by": "Sort by:",
+      "status": {
+        "all": "All",
+        "mine": "Mine",
+        "unassigned": "Unassigned",
+        "open": "Open",
+        "resolved": "Resolved"
+      },
+      "sort": {
+        "latest": "Latest",
+        "oldest": "Oldest",
+        "priority": "Priority",
+        "unread": "Unread",
+        "select_order": "Select sort order"
+      }
+    }
   },
   "contact": {
     "name": "Name",
@@ -53,7 +78,62 @@
     "password": "Password",
     "forgot_password": "Forgot password?",
     "reset_password": "Reset password",
-    "remember_me": "Remember me"
+    "remember_me": "Remember me",
+    "placeholders": {
+      "email": "name@example.com",
+      "password": "Enter your password"
+    },
+    "messages": {
+      "login_success": "Logged in successfully!"
+    },
+    "login_page": {
+      "title": "Sign in",
+      "description": "Enter your credentials to access your account. Seeded login is prefilled for instant testing.",
+      "submit": "Sign in",
+      "signing_in": "Signing in...",
+      "use_seeded_credentials": "Use seeded credentials",
+      "no_account": "Don't have an account?"
+    },
+    "signup_page": {
+      "title": "Create an account",
+      "description": "Enter your information to get started",
+      "full_name": "Full Name",
+      "confirm_password": "Confirm Password",
+      "password_hint": "Must be at least 8 characters",
+      "submit": "Create account",
+      "creating_account": "Creating account...",
+      "has_account": "Already have an account?",
+      "placeholders": {
+        "full_name": "John Doe",
+        "confirm_password": "Confirm your password"
+      },
+      "errors": {
+        "all_required": "All fields are required",
+        "password_mismatch": "Passwords do not match",
+        "password_min_length": "Password must be at least 8 characters"
+      },
+      "messages": {
+        "registration_success": "Registration successful! Please check your email to confirm your account.",
+        "registration_failed": "Registration failed. Please try again."
+      }
+    },
+    "layout": {
+      "tagline": "Customer engagement platform",
+      "footer_copyright": "© 2026 Chatwoot. All rights reserved."
+    },
+    "no_accounts": {
+      "title": "No Accounts Found",
+      "description": "You don't have access to any accounts in the system.",
+      "note": "Contact your administrator to be added to an account or create a new one.",
+      "create_account": "Create New Account",
+      "sign_out": "Sign Out"
+    },
+    "unauthorized": {
+      "title": "Access Denied",
+      "description": "You don't have permission to access this resource.",
+      "note": "Contact your administrator if you believe this is an error.",
+      "back_to_dashboard": "Back to Dashboard"
+    }
   },
   "errors": {
     "required": "This field is required",
@@ -69,7 +149,9 @@
     "success": "Success!",
     "error": "Error!",
     "warning": "Warning!",
-    "info": "Info"
+    "info": "Info",
+    "empty_state": "No notifications yet",
+    "load_more": "Load more"
   },
   "inbox": {
     "list": {
@@ -84,8 +166,7 @@
       "snoozed": "Snoozed",
       "read": "Read"
     }
-  }
-  ,
+  },
   "SIDEBAR": {
     "REPORTS_OVERVIEW": "Overview",
     "REPORTS_CONVERSATION": "Conversation",
@@ -96,8 +177,7 @@
     "CSAT": "CSAT",
     "REPORTS_SLA": "SLA",
     "REPORTS_BOT": "Bot"
-  }
-  ,
+  },
   "GENERAL_SETTINGS": {
     "TITLE": "General Settings",
     "SUBMIT": "Save changes",
@@ -177,8 +257,7 @@
       "NOTE": "Schedule permanent deletion of this account",
       "SCHEDULED_DELETION": {
         "MESSAGE_MANUAL": "This account is scheduled for deletion.",
-        "MESSAGE_INACTIVITY": "This account will be deleted due to inactivity."
-      ,
+        "MESSAGE_INACTIVITY": "This account will be deleted due to inactivity.",
         "CLEAR_BUTTON": "Clear scheduled deletion"
       },
       "CONFIRM": {

--- a/laravel-svelte-port/svelte-ui/src/lib/i18n/locales/en/index.json
+++ b/laravel-svelte-port/svelte-ui/src/lib/i18n/locales/en/index.json
@@ -119,7 +119,7 @@
     },
     "layout": {
       "tagline": "Customer engagement platform",
-      "footer_copyright": "© 2026 Chatwoot. All rights reserved."
+      "footer_copyright": "© {year} Chatwoot. All rights reserved."
     },
     "no_accounts": {
       "title": "No Accounts Found",

--- a/laravel-svelte-port/svelte-ui/src/routes/app/+page.svelte
+++ b/laravel-svelte-port/svelte-ui/src/routes/app/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { goto } from '$app/navigation';
+  import { _ } from '$lib/i18n';
   import { authStore } from '$lib/stores/auth.svelte';
   import { onMount } from 'svelte';
   
@@ -36,6 +37,6 @@
 
 <div class="flex items-center justify-center h-screen">
   <div class="text-center">
-    <p class="text-muted-foreground">Loading...</p>
+    <p class="text-muted-foreground">{$_('common.loading')}</p>
   </div>
 </div>

--- a/laravel-svelte-port/svelte-ui/src/routes/app/login/+layout@.svelte
+++ b/laravel-svelte-port/svelte-ui/src/routes/app/login/+layout@.svelte
@@ -6,6 +6,7 @@
   
   import type { Snippet } from 'svelte';
   import Logo from '$lib/components/layout/Logo.svelte';
+  import { _ } from '$lib/i18n';
   
   interface Props {
     children: Snippet;
@@ -21,7 +22,7 @@
         <Logo class="h-8 w-8" aria-label="Chatwoot logo" />
         <span class="text-3xl font-bold">Chatwoot</span>
       </div>
-      <p class="mt-2 text-sm text-muted-foreground">Customer engagement platform</p>
+      <p class="mt-2 text-sm text-muted-foreground">{$_('auth.layout.tagline')}</p>
     </div>
     
     <!-- Content -->
@@ -31,7 +32,7 @@
     
     <!-- Footer -->
     <div class="mt-8 text-center text-xs text-muted-foreground">
-      © 2026 Chatwoot. All rights reserved.
+      {$_('auth.layout.footer_copyright')}
     </div>
   </div>
 </div>

--- a/laravel-svelte-port/svelte-ui/src/routes/app/login/+layout@.svelte
+++ b/laravel-svelte-port/svelte-ui/src/routes/app/login/+layout@.svelte
@@ -32,7 +32,7 @@
     
     <!-- Footer -->
     <div class="mt-8 text-center text-xs text-muted-foreground">
-      {$_('auth.layout.footer_copyright')}
+      {$_('auth.layout.footer_copyright', { values: { year: new Date().getFullYear() } })}
     </div>
   </div>
 </div>

--- a/laravel-svelte-port/svelte-ui/src/routes/app/login/+page.svelte
+++ b/laravel-svelte-port/svelte-ui/src/routes/app/login/+page.svelte
@@ -9,6 +9,7 @@
   import { login } from '$lib/api/auth';
   import { getErrorMessage } from '$lib/api/errors';
   import { authStore } from '$lib/stores/auth.svelte';
+  import { _ } from '$lib/i18n';
   import { Button } from '$lib/components/ui/button';
   import { Input } from '$lib/components/ui/input';
   import { Label } from '$lib/components/ui/label';
@@ -43,7 +44,7 @@
 
         // Redirect based on user type
         if (response.user.type === 'SuperAdmin') {
-          toast.success('Logged in successfully!');
+          toast.success($_('auth.messages.login_success'));
           await goto(resolve('/app/super_admin/dashboard'));
           return;
         }
@@ -51,13 +52,13 @@
         // Regular user - redirect to their account's conversations page
         if (response.user.accounts && response.user.accounts.length > 0) {
           const firstAccount = response.user.accounts[0];
-          toast.success('Logged in successfully!');
+          toast.success($_('auth.messages.login_success'));
           await goto(resolve(`/app/accounts/${firstAccount.id}/conversations`));
           return;
         }
       }
 
-      toast.success('Logged in successfully!');
+      toast.success($_('auth.messages.login_success'));
       await goto(resolve('/app'));
     } catch (err: unknown) {
       error = getErrorMessage(err);
@@ -69,19 +70,19 @@
 
 <div class="space-y-6">
   <div class="space-y-2 text-center">
-    <h2 class="text-2xl font-semibold tracking-tight">Sign in</h2>
+    <h2 class="text-2xl font-semibold tracking-tight">{$_('auth.login_page.title')}</h2>
     <p class="text-sm text-muted-foreground">
-      Enter your credentials to access your account. Seeded login is prefilled for instant testing.
+      {$_('auth.login_page.description')}
     </p>
   </div>
 
   <form onsubmit={handleSubmit} class="space-y-4">
     <div class="space-y-2">
-      <Label for="email">Email</Label>
+      <Label for="email">{$_('auth.email')}</Label>
       <Input
         id="email"
         type="email"
-        placeholder="name@example.com"
+        placeholder={$_('auth.placeholders.email')}
         bind:value={email}
         required
         disabled={loading}
@@ -89,11 +90,11 @@
     </div>
 
     <div class="space-y-2">
-      <Label for="password">Password</Label>
+      <Label for="password">{$_('auth.password')}</Label>
       <Input
         id="password"
         type="password"
-        placeholder="Enter your password"
+        placeholder={$_('auth.placeholders.password')}
         bind:value={password}
         required
         disabled={loading}
@@ -107,7 +108,7 @@
     {/if}
 
     <Button type="submit" class="w-full" disabled={loading}>
-      {loading ? 'Signing in...' : 'Sign in'}
+      {loading ? $_('auth.login_page.signing_in') : $_('auth.login_page.submit')}
     </Button>
 
     <Button
@@ -117,18 +118,18 @@
       disabled={loading}
       onclick={useSeededCredentials}
     >
-      Use seeded credentials
+      {$_('auth.login_page.use_seeded_credentials')}
     </Button>
   </form>
 
   <div class="text-center text-sm">
     <a href={resolve('/auth/forgot-password')} class="text-primary hover:underline">
-      Forgot your password?
+      {$_('auth.forgot_password')}
     </a>
   </div>
 
   <div class="text-center text-sm text-muted-foreground">
-    Don't have an account?
-    <a href={resolve('/app/signup')} class="text-primary hover:underline">Sign up</a>
+    {$_('auth.login_page.no_account')}
+    <a href={resolve('/app/signup')} class="text-primary hover:underline">{$_('auth.signup')}</a>
   </div>
 </div>

--- a/laravel-svelte-port/svelte-ui/src/routes/app/no-accounts/+page.svelte
+++ b/laravel-svelte-port/svelte-ui/src/routes/app/no-accounts/+page.svelte
@@ -7,8 +7,8 @@
   import { Button } from '$lib/components/ui/button';
   import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '$lib/components/ui/card';
   import { authStore } from '$lib/stores/auth.svelte';
-  import { goto } from '$app/navigation';
-
+  import { _ } from '$lib/i18n';
+  
   async function handleCreateAccount() {
     // Redirect to account creation or show account creation form
     // This would depend on whether account creation from dashboard is enabled
@@ -24,21 +24,21 @@
 <div class="flex min-h-screen items-center justify-center bg-background p-4">
   <Card class="w-full max-w-md">
     <CardHeader class="text-center">
-      <CardTitle>No Accounts Found</CardTitle>
+      <CardTitle>{$_('auth.no_accounts.title')}</CardTitle>
       <CardDescription>
-        You don't have access to any accounts in the system.
+        {$_('auth.no_accounts.description')}
       </CardDescription>
     </CardHeader>
     <CardContent class="space-y-4">
       <p class="text-sm text-muted-foreground text-center">
-        Contact your administrator to be added to an account or create a new one.
+        {$_('auth.no_accounts.note')}
       </p>
       <div class="flex flex-col gap-2">
         <Button onclick={handleCreateAccount} class="w-full">
-          Create New Account
+          {$_('auth.no_accounts.create_account')}
         </Button>
         <Button variant="outline" onclick={handleLogout} class="w-full">
-          Sign Out
+          {$_('auth.no_accounts.sign_out')}
         </Button>
       </div>
     </CardContent>

--- a/laravel-svelte-port/svelte-ui/src/routes/app/signup/+page.svelte
+++ b/laravel-svelte-port/svelte-ui/src/routes/app/signup/+page.svelte
@@ -10,6 +10,7 @@
   import { register } from '$lib/api/auth';
   import { goto } from '$app/navigation';
   import { toast } from 'svelte-sonner';
+  import { _ } from '$lib/i18n';
   
   let name = $state('');
   let email = $state('');
@@ -24,17 +25,17 @@
     
     // Client-side validation
     if (!name || !email || !password || !passwordConfirmation) {
-      error = 'All fields are required';
+      error = $_('auth.signup_page.errors.all_required');
       return;
     }
     
     if (password !== passwordConfirmation) {
-      error = 'Passwords do not match';
+      error = $_('auth.signup_page.errors.password_mismatch');
       return;
     }
     
     if (password.length < 8) {
-      error = 'Password must be at least 8 characters';
+      error = $_('auth.signup_page.errors.password_min_length');
       return;
     }
     
@@ -58,7 +59,7 @@
       }
       
       // Show success message
-      toast.success(response.message || 'Registration successful! Please check your email to confirm your account.');
+      toast.success(response.message || $_('auth.signup_page.messages.registration_success'));
       
       // Redirect to app
       await goto('/app');
@@ -72,7 +73,7 @@
       } else if (err.message) {
         error = err.message;
       } else {
-        error = 'Registration failed. Please try again.';
+        error = $_('auth.signup_page.messages.registration_failed');
       }
     } finally {
       loading = false;
@@ -82,19 +83,19 @@
 
 <div class="space-y-6">
   <div class="space-y-2 text-center">
-    <h2 class="text-2xl font-semibold tracking-tight">Create an account</h2>
+    <h2 class="text-2xl font-semibold tracking-tight">{$_('auth.signup_page.title')}</h2>
     <p class="text-sm text-muted-foreground">
-      Enter your information to get started
+      {$_('auth.signup_page.description')}
     </p>
   </div>
   
   <form onsubmit={handleSubmit} class="space-y-4">
     <div class="space-y-2">
-      <Label for="name">Full Name</Label>
+      <Label for="name">{$_('auth.signup_page.full_name')}</Label>
       <Input
         id="name"
         type="text"
-        placeholder="John Doe"
+        placeholder={$_('auth.signup_page.placeholders.full_name')}
         bind:value={name}
         required
         disabled={loading}
@@ -102,11 +103,11 @@
     </div>
     
     <div class="space-y-2">
-      <Label for="email">Email</Label>
+      <Label for="email">{$_('auth.email')}</Label>
       <Input
         id="email"
         type="email"
-        placeholder="name@example.com"
+        placeholder={$_('auth.placeholders.email')}
         bind:value={email}
         required
         disabled={loading}
@@ -114,24 +115,24 @@
     </div>
     
     <div class="space-y-2">
-      <Label for="password">Password</Label>
+      <Label for="password">{$_('auth.password')}</Label>
       <Input
         id="password"
         type="password"
-        placeholder="Enter your password"
+        placeholder={$_('auth.placeholders.password')}
         bind:value={password}
         required
         disabled={loading}
       />
-      <p class="text-xs text-muted-foreground">Must be at least 8 characters</p>
+      <p class="text-xs text-muted-foreground">{$_('auth.signup_page.password_hint')}</p>
     </div>
     
     <div class="space-y-2">
-      <Label for="password-confirmation">Confirm Password</Label>
+      <Label for="password-confirmation">{$_('auth.signup_page.confirm_password')}</Label>
       <Input
         id="password-confirmation"
         type="password"
-        placeholder="Confirm your password"
+        placeholder={$_('auth.signup_page.placeholders.confirm_password')}
         bind:value={passwordConfirmation}
         required
         disabled={loading}
@@ -145,14 +146,14 @@
     {/if}
     
     <Button type="submit" class="w-full" disabled={loading}>
-      {loading ? 'Creating account...' : 'Create account'}
+      {loading ? $_('auth.signup_page.creating_account') : $_('auth.signup_page.submit')}
     </Button>
   </form>
   
   <div class="text-center text-sm text-muted-foreground">
-    Already have an account?{' '}
+    {$_('auth.signup_page.has_account')}{' '}
     <a href="/app/login" class="text-primary hover:underline">
-      Sign in
+      {$_('auth.login_page.title')}
     </a>
   </div>
 </div>

--- a/laravel-svelte-port/svelte-ui/src/routes/app/unauthorized/+page.svelte
+++ b/laravel-svelte-port/svelte-ui/src/routes/app/unauthorized/+page.svelte
@@ -8,19 +8,20 @@
   import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '$lib/components/ui/card';
   import { authStore } from '$lib/stores/auth.svelte';
   import { goto } from '$app/navigation';
+  import { _ } from '$lib/i18n';
 </script>
 
 <div class="flex min-h-screen items-center justify-center bg-background p-4">
   <Card class="w-full max-w-md">
     <CardHeader class="text-center">
-      <CardTitle class="text-xl">Access Denied</CardTitle>
+      <CardTitle class="text-xl">{$_('auth.unauthorized.title')}</CardTitle>
       <CardDescription>
-        You don't have permission to access this resource.
+        {$_('auth.unauthorized.description')}
       </CardDescription>
     </CardHeader>
     <CardContent class="text-center">
       <p class="text-sm text-muted-foreground">
-        Contact your administrator if you believe this is an error.
+        {$_('auth.unauthorized.note')}
       </p>
     </CardContent>
     <CardFooter class="flex flex-col gap-2">
@@ -28,14 +29,14 @@
         onclick={() => goto('/app')} 
         class="w-full"
       >
-        Back to Dashboard
+        {$_('auth.unauthorized.back_to_dashboard')}
       </Button>
       <Button 
         variant="outline" 
         onclick={() => authStore.logout()} 
         class="w-full"
       >
-        Sign Out
+        {$_('auth.no_accounts.sign_out')}
       </Button>
     </CardFooter>
   </Card>


### PR DESCRIPTION
### Motivation

- Remove hardcoded, user-visible strings in the app routes and shared components and replace them with the existing i18n accessor so the UI can be translated and maintained consistently.
- Ensure placeholders, button labels, status badges, empty states and loading text follow the project i18n namespace conventions.
- Add missing English keys to the `en` locale so all new accessors resolve.
- Provide a small reviewer checklist to prevent future hardcoded-string regressions.

### Description

- Replaced hardcoded strings with i18n accessor usage (`$_('...')`) in key auth and app routes and layouts under `src/routes/app/**` (including `+page.svelte`, `login`, `signup`, `no-accounts`, `unauthorized`, and login layout). 
- Localized shared component strings in `src/lib/components/**` including notifications empty state and load-more button, `BarChart` tooltip/empty messages, and conversation filter tabs/badge overflow/sort label (`ConversationFilters.svelte`, `NotificationList.svelte`, `BarChart.svelte`).
- Added the new English keys to `src/lib/i18n/locales/en/index.json` following existing namespaces (`auth`, `common`, `notifications`, `conversation`) for placeholders, page copy, button labels, empty states, badges, and sort labels.
- Added `LOCALIZATION_REVIEW_CHECKLIST.md` at the Svelte UI root with a short checklist to catch future hardcoded UI strings.

### Testing

- Ran `pnpm format` / Prettier across the workspace to normalize changes and formatting; the formatting run completed successfully.
- Ran `pnpm check` (which invokes `svelte-kit sync` and `svelte-check`); this failed in this environment because project dependencies are not installed (`svelte-kit: not found`).
- Attempted a preview screenshot via Playwright to validate the login page rendering, but no dev server responded on the forwarded port so the screenshot attempt failed.
- No unit test changes were needed; type/lint/build checks should be run in CI or locally after `pnpm install` to validate integration with full project toolchain.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69900df704e4832aa42567fa90b54f5c)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Internationalization framework integrated across login, signup, authentication, and notification interfaces
  * Support for localized text across UI components including charts, filters, and status messages
  * Expanded English locale with comprehensive translation keys for improved multi-language readiness

* **Documentation**
  * Added localization review checklist for maintaining consistent translation practices

<!-- end of auto-generated comment: release notes by coderabbit.ai -->